### PR TITLE
getGID seems to be throwing errors on valid gallery urls. closes #39

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MotherlessRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MotherlessRipper.java
@@ -47,7 +47,7 @@ public class MotherlessRipper extends AlbumRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("^https?://(www\\.)?motherless\\.com/G([MVI][A-F0-9]{6,8}).*$");
+        Pattern p = Pattern.compile("^https?://(www\\.)?motherless\\.com/G([MVI]?[A-F0-9]{6,8}).*$");
         Matcher m = p.matcher(url.toExternalForm());
         System.err.println(url.toExternalForm());
         if (!m.matches()) {


### PR DESCRIPTION
Changed the [MVI] to an optional character because it seems it is not always there.

tested on
http://motherless.com/G597ED24

closes #39 
