### PR TITLE
Fixed tumblr url redirect

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
@@ -8,7 +8,6 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
-
 import com.rarchives.ripme.ripper.AlbumRipper;
 import com.rarchives.ripme.ui.RipStatusMessage.STATUS;
 import com.rarchives.ripme.utils.Http;


### PR DESCRIPTION
Tumblr ripper did not account for normal urls in the original_size field.  Tumblr will pass a redirect url rather then an image path if the image size is too big to host themselves... looks like anything >=800x600.
I check to see if the url has a valid image file extension, if it does not i treat it as a url.  
The url redirects to an AWS image.  So I ignore the content type and get the response url to download
