### PR TITLE
Added login cookie support and paging fixes for FlickrRipper.java and some...

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -64,8 +64,11 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
         sendUpdate(STATUS.LOADING_RESOURCE, this.url.toExternalForm());
         Document doc = getFirstPage();
         
+        boolean first = true;
+        
         while (doc != null) {
             List<String> imageURLs = getURLsFromPage(doc);
+
             // Remove all but 1 image
             if (isThisATest()) {
                 while (imageURLs.size() > 1) {
@@ -73,8 +76,15 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
                 }
             }
 
+            //if (imageURLs.size() == 0) {
             if (imageURLs.size() == 0) {
-                throw new IOException("No images found at " + doc.location());
+            	if (first) {
+            		throw new IOException("No images found at " + doc.location());
+            	}
+            	else {
+            		logger.info("No images in page...");
+            		break;
+            	}
             }
             
             for (String imageURL : imageURLs) {
@@ -115,6 +125,8 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
                 logger.info("Can't get next page: " + e.getMessage());
                 break;
             }
+            
+            first = false;
         }
 
         // If they're using a thread pool, wait for it.

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PicasaRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PicasaRipper.java
@@ -1,0 +1,124 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class PicasaRipper extends AbstractHTMLRipper {
+
+    private Document albumDoc = null;
+
+    public PicasaRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "picasa";
+    }
+    @Override
+    public String getDomain() {
+        return "picasaweb.google.com";
+    }
+    
+    @Override
+    public Document getFirstPage() throws IOException {
+        if (albumDoc == null) {
+            albumDoc = Http.url(url).get();
+        }
+        return albumDoc;
+    }
+    
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        return null;
+    }
+    
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> imageURLs = new ArrayList<String>();
+        //for (Element thumb : doc.select("#lhid_content img")) 
+        for (Element thumb : doc.select("img"))
+        {
+        	if (!thumb.hasAttr("src")) {
+                continue;
+            }
+        	
+        	if (thumb.hasAttr("id") || thumb.hasAttr("width") || thumb.hasAttr("height"))
+        		continue;
+        	
+        	/*
+        	String cls = thumb.attr("class");
+        	if (cls == null || !cls.equals("goog-icon-list-icon-img"))
+        			continue;
+        	*/
+
+            String image = thumb.attr("src");
+            image = image.replaceAll(
+                    "/s128/",
+                    "/d/");
+            imageURLs.add(image);
+        }
+        return imageURLs;
+    }
+    
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+    
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+
+        Pattern p; Matcher m;
+
+        p = Pattern.compile("^.*picasaweb.google.com/([0-9]+).*$");
+        m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+
+        throw new MalformedURLException(
+                "Expected picasaweb.google.com gallery formats: "
+                        + "picasaweb.google.com/<ID>/... "
+                        + " Got: " + url);
+    }
+ 	
+    @Override
+    public String getAlbumTitle(URL url) throws MalformedURLException {
+    	
+    	try {
+        	String inUrl = url.toExternalForm();
+        	String sUrl;
+        	
+            if (inUrl.endsWith("/"))
+            	sUrl = inUrl.substring(0, inUrl.length()-1);
+            else
+            	sUrl = inUrl;
+
+            String id = sUrl.substring(sUrl.lastIndexOf('/') + 1);
+        	id = id.replaceAll("noredirect=1", "");
+        	
+            if (id.endsWith("?"))
+            	id = id.substring(0, id.length()-1);
+
+        	return getHost() + "_" + getGID(url) + "_" + id;
+			
+        } catch (Exception e) {
+            // Fall back to default album naming convention
+        }
+    	
+    	return super.getAlbumTitle(url);
+    }
+
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/UsenethubRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/UsenethubRipper.java
@@ -1,0 +1,133 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class UsenethubRipper extends AbstractHTMLRipper {
+
+    private Document albumDoc = null;
+
+    public UsenethubRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "usenethub";
+    }
+    @Override
+    public String getDomain() {
+        return "adult.usenethub.com";
+    }
+    
+    @Override
+    public Document getFirstPage() throws IOException {
+        if (albumDoc == null) {
+            albumDoc = Http.url(url).get();
+        }
+        return albumDoc;
+    }
+    
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        String nextURL = null;
+        for (Element a : doc.select("a.paging_next")) {
+            if (a.text().contains("→")) {
+                nextURL = "http://adult.usenethub.com" + a.attr("href");
+                break;
+            }
+        }
+        if (nextURL == null) {
+            throw new IOException("No next page found");
+        }
+        sleep(1000);
+        return Http.url(nextURL).get();
+    }
+    
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> imageURLs = new ArrayList<String>();
+        for (Element thumb : doc.select("#classic img")) {
+
+        	if (!thumb.hasAttr("src") || !thumb.hasAttr("alt")) {
+                continue;
+            }
+
+        	if (thumb.attr("alt").length() == 0 && thumb.hasAttr("width") && thumb.hasAttr("height")) {
+        		continue;
+        	}
+            
+            String image = thumb.attr("src");
+            image = image.replaceAll(
+                    "http://usebin.org/image/",
+                    "http://usebin.org/source/");
+            imageURLs.add(image);
+        }
+        return imageURLs;
+    }
+    
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+
+    /*
+ 	@Override
+	public String getGID(URL url) throws MalformedURLException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+	*/
+ 	
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+
+    	String inUrl = url.toExternalForm();
+    	String sUrl;
+    	
+        if (inUrl.endsWith("/"))
+        	sUrl = inUrl.substring(0, inUrl.length()-1);
+        else
+        	sUrl = inUrl;
+
+        String id = sUrl.substring(sUrl.lastIndexOf('/') + 1);
+
+        if (id != null && id.length() > 0)
+        	return id;
+
+        throw new MalformedURLException(
+                "Expected usenethub.com gallery formats: "
+                        + "imagefap.com/gallery.php?gid=####... or "
+                        + "imagefap.com/pictures/####..."
+                        + " Got: " + url);
+    }
+ 	
+
+    @Override
+    public String getAlbumTitle(URL url) throws MalformedURLException {
+        try {
+            // Attempt to use album title as GID
+            String title = getFirstPage().title();
+            Pattern p = Pattern.compile("^(.*) \\(Usenet Download\\)$");
+            Matcher m = p.matcher(title);
+            if (m.matches()) {
+                return getHost() + "_" + m.group(1);
+            }
+        } catch (IOException e) {
+            // Fall back to default album naming convention
+        }
+        return super.getAlbumTitle(url);
+    }
+
+}

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -100,6 +100,11 @@ public class Utils {
         config.clearProperty(key);
         config.addProperty(key, list);
     }
+    
+    public static void clearConfigProperty(String key)
+    {
+    	config.clearProperty(key);
+    }
 
     public static void saveConfig() {
         try {


### PR DESCRIPTION
Just get cookies from browser after logging in to Flickr and put one line in the config. After 1st time, cookies will be Base64 encoded in the config for some very simple security measure.

-- How to get cookies easily (for end users) --

Chrome Browser:
- Login to Flickr
- Hit F12 for Developer Tools in browser
- Go to Resources tab
- Expand Cookies on the left
- Select www.flickr.com
- Get the values for these 3 cookies: <cookie_accid>, <cookie_epass> and <current_identity>
- Put these in the "rip.properties" file like this. That's it. (Replace ### with the values)

flickr.cookies2encode = current_identity=###; cookie_accid=###; cookie_epass=###;

* Added clearConfigProperty(...) to Utils.java
* Modified AbstractHTMLRipper.java so that "no images found" IOException is thrown only for the 1st page. The rest will just log and break out of the while loop.
* Added UsenetHub ripper. (http://adult.usenethub.com)
* Added Picasa Web Albums ripper. (http://picasaweb.google.com)