### PR TITLE
Use :orig instead of :large in TwitterRipper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TwitterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TwitterRipper.java
@@ -184,7 +184,7 @@ public class TwitterRipper extends AlbumRipper {
                 media = (JSONObject) medias.get(i);
                 url = media.getString("media_url");
                 if (url.contains(".twimg.com/")) {
-                    url += ":large";
+                    url += ":orig";
                     addURLToDownload(new URL(url));
                     return true;
                 }


### PR DESCRIPTION
This patch will allow TwitterRipper to download the original image instead of the resized large image

Normal image (600×300) → https://pbs.twimg.com/media/CCiZIc-WgAAc9vx.jpg
Large image (1024×512) → https://pbs.twimg.com/media/CCiZIc-WgAAc9vx.jpg:large
Original image (1280×640) → https://pbs.twimg.com/media/CCiZIc-WgAAc9vx.jpg:orig