### PR TITLE
xhamster cookie support, prettier naming, and single-picture ripping.

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -106,23 +106,9 @@ public abstract class AbstractRipper
             return false;
         }
         logger.debug("url: " + url + ", prefix: " + prefix + ", subdirectory" + subdirectory + ", referrer: " + referrer + ", cookies: " + cookies);
-        String saveAs = url.toExternalForm();
-        saveAs = saveAs.substring(saveAs.lastIndexOf('/')+1);
-        if (saveAs.indexOf('?') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('?')); }
-        if (saveAs.indexOf('#') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('#')); }
-        if (saveAs.indexOf('&') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('&')); }
-        if (saveAs.indexOf(':') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf(':')); }
         File saveFileAs;
         try {
-            if (!subdirectory.equals("")) {
-                subdirectory = File.separator + subdirectory;
-            }
-            saveFileAs = new File(
-                    workingDir.getCanonicalPath()
-                    + subdirectory
-                    + File.separator
-                    + prefix
-                    + saveAs);
+            saveFileAs = getSaveAsFile(url, prefix, subdirectory);
         } catch (IOException e) {
             logger.error("[!] Error creating save file path for URL '" + url + "':", e);
             return false;
@@ -134,7 +120,26 @@ public abstract class AbstractRipper
         }
         return addURLToDownload(url, saveFileAs, referrer, cookies);
     }
-    
+
+    protected File getSaveAsFile(URL url, String prefix, String subdirectory) throws IOException {
+        String saveAs = url.toExternalForm();
+        saveAs = saveAs.substring(saveAs.lastIndexOf('/')+1);
+        if (saveAs.indexOf('?') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('?')); }
+        if (saveAs.indexOf('#') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('#')); }
+        if (saveAs.indexOf('&') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('&')); }
+        if (saveAs.indexOf(':') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf(':')); }
+        File saveFileAs;
+        if (!subdirectory.equals("")) {
+            subdirectory = File.separator + subdirectory;
+        }
+        saveFileAs = new File(
+            workingDir.getCanonicalPath()
+            + subdirectory
+            + File.separator
+            + prefix
+            + saveAs);
+        return saveFileAs;
+    }
     
     /**
      * Queues file to be downloaded and saved. With options.

--- a/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
@@ -83,6 +83,18 @@ public abstract class AlbumRipper extends AbstractRipper {
     }
 
     @Override
+    public boolean addURLToDownload(URL url, String prefix, String subdirectory, String referrer, Map<String,String> cookies) {
+        File saveFileAs;
+        try {
+            saveFileAs = getSaveAsFile(url, prefix, subdirectory);
+        } catch (IOException e) {
+            logger.error("[!] Error creating save file path for URL '" + url + "':", e);
+            return false;
+        }
+        return addURLToDownload(url, saveFileAs, referrer, cookies);
+    }
+
+    @Override
     public boolean addURLToDownload(URL url, File saveAs) {
         return addURLToDownload(url, saveAs, null, null);
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -3,6 +3,8 @@ package com.rarchives.ripme.ripper.rippers;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -16,6 +18,8 @@ import com.rarchives.ripme.utils.Utils;
 public class XhamsterRipper extends AlbumRipper {
 
     private static final String HOST = "xhamster";
+
+    private HashMap<String, Document> docs = new HashMap<String, Document>();
 
     public XhamsterRipper(URL url) throws IOException {
         super(url);
@@ -39,7 +43,7 @@ public class XhamsterRipper extends AlbumRipper {
         String nextURL = this.url.toExternalForm();
         while (nextURL != null) {
             logger.info("    Retrieving " + nextURL);
-            Document doc = Http.url(nextURL).get();
+            Document doc = Http.url(nextURL).header("User-Agent", USER_AGENT).referrer("http://" + HOST + ".com/").cookies(Utils.getCookies(HOST)).get();
             for (Element thumb : doc.select("table.iListing div.img img")) {
                 if (!thumb.hasAttr("src")) {
                     continue;
@@ -73,6 +77,36 @@ public class XhamsterRipper extends AlbumRipper {
         waitForThreads();
     }
 
+    /**
+     * @todo prefix with uploader username
+     */
+    @Override
+    public String getAlbumTitle(URL url) throws MalformedURLException {
+        String title = HOST + "_";
+        Document doc = docs.get(url);;
+        if (doc == null) {
+            try {
+                doc = Http.url(url).header("User-Agent", USER_AGENT).referrer(url).cookies(Utils.getCookies(HOST)).get();
+                docs.put(url.toString(), doc);
+            } catch (IOException e) {
+                logger.error("Failed to download url=" + url + ": " + e.getMessage());
+            }
+        }
+        // Find username.
+        if (doc != null) {
+            for (Element link : doc.select("#galleryUser .item a")) {
+                title += link.text() + "_";
+                break;
+            }
+        }
+        String galleryLink = url.toExternalForm();
+        title += galleryLink
+            .replaceFirst("^http.*/photos/(?:gallery/([^?#:&]+)|view/([^-]+)-).*$", "$1$2")
+            .replace('/', '-')
+            .replace(".html", "");
+        return title;
+    }
+
     @Override
     public String getHost() {
         return HOST;
@@ -80,15 +114,14 @@ public class XhamsterRipper extends AlbumRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("^https?://([a-z0-9.]*?)xhamster\\.com/photos/gallery/([0-9]{1,})/.*\\.html");
-        Matcher m = p.matcher(url.toExternalForm());
-        if (m.matches()) {
-            return m.group(2);
-        }
-        throw new MalformedURLException(
+        String gid = url.toExternalForm().replaceFirst("^https?://(?:[a-z0-9.]*?)" + HOST + "\\.com/photos/(?:gallery/([0-9]{1,})/.*\\.html|view/([^-]+)-).*$", "$1$2");
+        if (gid.length() == 0) {
+            throw new MalformedURLException(
                 "Expected xhamster.com gallery formats: "
-                        + "xhamster.com/photos/gallery/#####/xxxxx..html"
-                        + " Got: " + url);
+                + "http://xhamster.com/photos/gallery/#####/xxxxx..html or http://xhamster.com/photos/view/####-####.html"
+                + " Got: " + url);
+        }
+        return gid;
     }
 
 }

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -9,7 +9,9 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -69,6 +71,11 @@ public class Utils {
         } catch (Exception e) {
             logger.error("[!] Failed to load properties file from " + configFile, e);
         }
+    }
+
+    private static HashMap<String, HashMap<String, String>> cookieCache;
+    static {
+        cookieCache = new HashMap<String, HashMap<String, String>>();
     }
 
     /**
@@ -386,5 +393,22 @@ public class Utils {
             i = fullText.indexOf(start, j + finish.length());
         }
         return result;
+    }
+
+    public static Map<String, String> getCookies(String host) {
+        HashMap<String, String> domainCookies = cookieCache.get(host);
+        if (domainCookies == null) {
+            domainCookies = new HashMap<String, String>();
+            String cookiesConfig = getConfigString("cookies." + host, "");
+            for (String pair : cookiesConfig.split(" ")) {
+                pair = pair.trim();
+                if (pair.contains("=")) {
+                    String[] pieces = pair.split("=", 2);
+                    domainCookies.put(pieces[0], pieces[1]);
+                }
+            }
+            cookieCache.put(host, domainCookies);
+        }
+        return domainCookies;
     }
 }

--- a/src/main/resources/rip.properties
+++ b/src/main/resources/rip.properties
@@ -30,3 +30,7 @@ twitter.max_requests = 10
 clipboard.autorip = false
 
 download.save_order = true
+
+cookies.xhamster =
+# e.g. cookies.xhamster = USERNAME=sleaze UID=69696969 PWD=144354bc90792a91957df1ef962908c1 fingerprint=d65f704a8fef31b5327175e00f1eeb85
+

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BasicRippersTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BasicRippersTest.java
@@ -169,7 +169,7 @@ public class BasicRippersTest extends RippersTest {
     }
 
     public void testImgboxRip() throws IOException {
-        AbstractRipper ripper = new ImgboxRipper(new URL("http://imgbox.com/g/sEMHfsqx4w"));
+        AbstractRipper ripper = new ImgboxRipper(new URL("http://imgbox.com/g/z7Bj2FjxJX"));
         testRipper(ripper);
     }
 


### PR DESCRIPTION
# Cookies

Set cookie value in rip.properties and it'll be automatically used from that point forward.

Also has the potential for generalized use by setting:

    <HOSTNAME>.cookies = key1=value1 key2=value2 ...

In rip.properties.

E.g.:

    xhamster.cookies = USERNAME=sleaze secrethash=aANVao8023u29380r2hoiajJloLWOEz
    twitter.cookies = ...

# Pretty naming

Xhamster usernames and gallery names are now incorporated into the folder names.

# Single-picture ripping

Xhamster single-image URLs are now ripping, and both the JPG and HTML files are saved.

Also, when ripping a gallery the index.html file is now saved.