### PR TITLE
Eroshare naming enhancements and XhamsterRipper method refactoring.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ ripme.jar.update
 ripme.jar
 rip.properties
 history.json
+.idea
+*.iml

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -38,7 +38,7 @@ public class App {
         Utils.configureLogger();
         System.setProperty("apple.laf.useScreenMenuBar", "true");
         System.setProperty("com.apple.mrj.application.apple.menu.about.name", "RipMe");
-        logger  = Logger.getLogger(App.class);
+        logger = Logger.getLogger(App.class);
         logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
 
         if (args.length > 0) {

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -106,23 +106,9 @@ public abstract class AbstractRipper
             return false;
         }
         logger.debug("url: " + url + ", prefix: " + prefix + ", subdirectory" + subdirectory + ", referrer: " + referrer + ", cookies: " + cookies);
-        String saveAs = url.toExternalForm();
-        saveAs = saveAs.substring(saveAs.lastIndexOf('/')+1);
-        if (saveAs.indexOf('?') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('?')); }
-        if (saveAs.indexOf('#') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('#')); }
-        if (saveAs.indexOf('&') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('&')); }
-        if (saveAs.indexOf(':') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf(':')); }
         File saveFileAs;
         try {
-            if (!subdirectory.equals("")) {
-                subdirectory = File.separator + subdirectory;
-            }
-            saveFileAs = new File(
-                    workingDir.getCanonicalPath()
-                    + subdirectory
-                    + File.separator
-                    + prefix
-                    + saveAs);
+            saveFileAs = getSaveAsFile(url, prefix, subdirectory);
         } catch (IOException e) {
             logger.error("[!] Error creating save file path for URL '" + url + "':", e);
             return false;
@@ -134,7 +120,26 @@ public abstract class AbstractRipper
         }
         return addURLToDownload(url, saveFileAs, referrer, cookies);
     }
-    
+
+    protected File getSaveAsFile(URL url, String prefix, String subdirectory) throws IOException {
+        String saveAs = url.toExternalForm();
+        saveAs = saveAs.substring(saveAs.lastIndexOf('/')+1);
+        if (saveAs.indexOf('?') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('?')); }
+        if (saveAs.indexOf('#') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('#')); }
+        if (saveAs.indexOf('&') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('&')); }
+        if (saveAs.indexOf(':') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf(':')); }
+        File saveFileAs;
+        if (!subdirectory.equals("")) {
+            subdirectory = File.separator + subdirectory;
+        }
+        saveFileAs = new File(
+            workingDir.getCanonicalPath()
+            + subdirectory
+            + File.separator
+            + prefix
+            + saveAs);
+        return saveFileAs;
+    }
     
     /**
      * Queues file to be downloaded and saved. With options.

--- a/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
@@ -83,6 +83,18 @@ public abstract class AlbumRipper extends AbstractRipper {
     }
 
     @Override
+    public boolean addURLToDownload(URL url, String prefix, String subdirectory, String referrer, Map<String,String> cookies) {
+        File saveFileAs;
+        try {
+            saveFileAs = getSaveAsFile(url, prefix, subdirectory);
+        } catch (IOException e) {
+            logger.error("[!] Error creating save file path for URL '" + url + "':", e);
+            return false;
+        }
+        return addURLToDownload(url, saveFileAs, referrer, cookies);
+    }
+
+    @Override
     public boolean addURLToDownload(URL url, File saveAs) {
         return addURLToDownload(url, saveAs, null, null);
     }

--- a/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
@@ -1,10 +1,13 @@
 package com.rarchives.ripme.ripper;
 
+import com.rarchives.ripme.utils.Http;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -12,12 +15,15 @@ import java.util.Map;
 import com.rarchives.ripme.ui.RipStatusMessage;
 import com.rarchives.ripme.ui.RipStatusMessage.STATUS;
 import com.rarchives.ripme.utils.Utils;
+import org.jsoup.nodes.Document;
 
 public abstract class AlbumRipper extends AbstractRipper {
 
     protected Map<URL, File> itemsPending = Collections.synchronizedMap(new HashMap<URL, File>());
     protected Map<URL, File> itemsCompleted = Collections.synchronizedMap(new HashMap<URL, File>());
     protected Map<URL, String> itemsErrored = Collections.synchronizedMap(new HashMap<URL, String>());
+
+    protected HashMap<String, Document> docs = new HashMap<String, Document>();
 
     public AlbumRipper(URL url) throws IOException {
         super(url);
@@ -221,5 +227,30 @@ public abstract class AlbumRipper extends AbstractRipper {
           .append(", Completed: ").append(itemsCompleted.size())
           .append(", Errored: "  ).append(itemsErrored.size());
         return sb.toString();
+    }
+
+    protected Document downloadAndSaveHTML(URL url) throws IOException {
+        String urlString = url.toExternalForm();
+        Document doc = docs.get(urlString);
+        if (doc == null) {
+            doc = Http.url(url).header("User-Agent", USER_AGENT).referrer(url).cookies(Utils.getCookies(getHost())).get();
+            docs.put(urlString, doc);
+        }
+        String filename = urlToFilename(url);
+        if (getWorkingDir() != null) {
+            Files.write(Paths.get(getWorkingDir().getCanonicalPath() + File.separator + filename), doc.toString().getBytes());
+        }
+        return doc;
+    }
+
+    protected static String urlToFilename(URL url) {
+        String filename = url.toExternalForm().replaceFirst("^https?://.*/", "").replaceFirst("[#&:].*$", "");
+        if (filename.contains("?") && filename.contains(".")) {
+            int periodIdx = filename.lastIndexOf('.');
+            int questionMarkIdx = filename.indexOf('?');
+            String params = filename.substring(questionMarkIdx + 1).replaceAll("=", "-").replaceAll("&", "_");
+            filename = filename.substring(0, periodIdx) + "_" + params + filename.substring(periodIdx, questionMarkIdx);
+        }
+        return filename;
     }
 }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -37,14 +37,12 @@ public class InstagramRipper extends AbstractJSONRipper {
 
     @Override
     public boolean canRip(URL url) {
-        return (url.getHost().endsWith("instagram.com")
-             || url.getHost().endsWith("statigr.am")
-             || url.getHost().endsWith("iconosquare.com/"));
+        return (url.getHost().endsWith("instagram.com"));
     }
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("^https?://iconosquare.com/([a-zA-Z0-9\\-_.]{3,}).*$");
+        Pattern p = Pattern.compile("^https?://instagram.com/([^/]+)");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);
@@ -54,106 +52,70 @@ public class InstagramRipper extends AbstractJSONRipper {
 
     @Override
     public URL sanitizeURL(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("^https?://instagram\\.com/p/([a-zA-Z0-9\\-_.]{1,}).*$");
+        Pattern p = Pattern.compile("^.*instagram\\.com/([a-zA-Z0-9\\-_.]{3,}).*$");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
-            // Link to photo, not the user account
-            try {
-                url = getUserPageFromImage(url);
-            } catch (Exception e) {
-                logger.error("[!] Failed to get user page from " + url, e);
-                throw new MalformedURLException("Failed to retrieve user page from " + url);
-            }
+            return new URL("http://instagram.com/" + m.group(1));
         }
-        p = Pattern.compile("^.*instagram\\.com/([a-zA-Z0-9\\-_.]{3,}).*$");
-        m = p.matcher(url.toExternalForm());
-        if (m.matches()) {
-            return new URL("http://iconosquare.com/" + m.group(1));
-        }
-        p = Pattern.compile("^.*iconosquare\\.com/([a-zA-Z0-9\\-_.]{3,}).*$");
-        m = p.matcher(url.toExternalForm());
-        if (m.matches()) {
-            return new URL("http://iconosquare.com/" + m.group(1));
-        }
-        p = Pattern.compile("^.*statigr\\.am/([a-zA-Z0-9\\-_.]{3,}).*$");
-        m = p.matcher(url.toExternalForm());
-        if (m.matches()) {
-            return new URL("http://iconosquare.com/" + m.group(1));
-        }
-        throw new MalformedURLException("Expected username in URL (instagram.com/username and not " + url);
-    }
-    
-    private URL getUserPageFromImage(URL url) throws IOException {
-        Document doc = Http.url(url).get();
-        for (Element element : doc.select("meta[property='og:description']")) {
-            String content = element.attr("content");
-            if (content.endsWith("'s photo on Instagram")) {
-                return new URL("http://iconosquare/" + content.substring(0, content.indexOf("'")));
-            }
-        }
+
         throw new MalformedURLException("Expected username in URL (instagram.com/username and not " + url);
     }
     
     private String getUserID(URL url) throws IOException {
-        this.sendUpdate(STATUS.LOADING_RESOURCE, url.toExternalForm());
-        Document doc = Http.url(url).get();
-        for (Element element : doc.select("input[id=user_public]")) {
-            return element.attr("value");
+
+        Pattern p = Pattern.compile("^https?://instagram\\.com/([^/]+)");
+        Matcher m = p.matcher(url.toExternalForm());
+        if(m.matches()) {
+            return m.group(1);
         }
+
         throw new IOException("Unable to find userID at " + this.url);
     }
     
     @Override
     public JSONObject getFirstPage() throws IOException {
         userID = getUserID(url);
-        String baseURL = "http://iconosquare.com/controller_nl.php?action=getPhotoUserPublic&user_id="
-                        + userID;
-        logger.info("Loading " + baseURL);
+
+        String baseURL = "http://instagram.com/" + userID + "/media";
         try {
             JSONObject result = Http.url(baseURL).getJSON();
             return result;
         } catch (JSONException e) {
-            throw new IOException("Could not get instagram user via iconosquare", e);
+            throw new IOException("Could not get instagram user via: " + baseURL);
         }
     }
 
     @Override
     public JSONObject getNextPage(JSONObject json) throws IOException {
-        if (isThisATest()) {
-            return null;
+
+        boolean nextPageAvailable;
+        try {
+            nextPageAvailable = json.getBoolean("more_available");
+        } catch (Exception e) {
+            throw new IOException("No additional pages found");
         }
-        JSONObject pagination = json.getJSONObject("pagination");
-        String nextMaxID = "";
-        JSONArray datas = json.getJSONArray("data");
-        for (int i = 0; i < datas.length(); i++) {
-            JSONObject data = datas.getJSONObject(i);
-            if (data.has("id")) {
-                nextMaxID = data.getString("id");
-            }
-        }
-        if (nextMaxID.equals("")) {
-            if (!pagination.has("next_max_id")) {
-                throw new IOException("No next_max_id found, stopping");
-            }
-            nextMaxID = pagination.getString("next_max_id");
-        }
-        String baseURL = "http://iconosquare.com/controller_nl.php?action=getPhotoUserPublic&user_id="
-                        + userID
-                        + "&max_id=" + nextMaxID;
-        logger.info("Loading " + baseURL);
-        sleep(1000);
-        JSONObject nextJSON = Http.url(baseURL).getJSON();
-        datas = nextJSON.getJSONArray("data");
-        if (datas.length() == 0) {
+
+        if(nextPageAvailable) {
+            JSONArray items         = json.getJSONArray("items");
+            JSONObject last_item    = items.getJSONObject(items.length() - 1);
+            String nextMaxID        = last_item.getString("id");
+
+            String baseURL = "http://instagram.com/" + userID + "/media/?max_id=" + nextMaxID;
+            logger.info("Loading " + baseURL);
+            sleep(1000);
+
+            JSONObject nextJSON = Http.url(baseURL).getJSON();
+
+            return nextJSON;
+        } else {
             throw new IOException("No more images found");
         }
-        return nextJSON;
     }
     
     @Override
     public List<String> getURLsFromJSON(JSONObject json) {
         List<String> imageURLs = new ArrayList<String>();
-        JSONArray datas = json.getJSONArray("data");
+        JSONArray datas = json.getJSONArray("items");
         for (int i = 0; i < datas.length(); i++) {
             JSONObject data = (JSONObject) datas.get(i);
             String imageURL;
@@ -166,6 +128,7 @@ public class InstagramRipper extends AbstractJSONRipper {
             }
             imageURL = imageURL.replaceAll("scontent.cdninstagram.com/hphotos-", "igcdn-photos-d-a.akamaihd.net/hphotos-ak-");
             imageURL = imageURL.replaceAll("s640x640/", "");
+            imageURL = imageURL.replaceAll("\\?ig_cache_key.+$", "");
             imageURLs.add(imageURL);
             if (isThisATest()) {
                 break;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -3,6 +3,8 @@ package com.rarchives.ripme.ripper.rippers;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -16,6 +18,8 @@ import com.rarchives.ripme.utils.Utils;
 public class XhamsterRipper extends AlbumRipper {
 
     private static final String HOST = "xhamster";
+
+    private HashMap<String, Document> docs = new HashMap<String, Document>();
 
     public XhamsterRipper(URL url) throws IOException {
         super(url);
@@ -39,7 +43,7 @@ public class XhamsterRipper extends AlbumRipper {
         String nextURL = this.url.toExternalForm();
         while (nextURL != null) {
             logger.info("    Retrieving " + nextURL);
-            Document doc = Http.url(nextURL).get();
+            Document doc = Http.url(nextURL).header("User-Agent", USER_AGENT).referrer("http://" + HOST + ".com/").cookies(Utils.getCookies(HOST)).get();
             for (Element thumb : doc.select("table.iListing div.img img")) {
                 if (!thumb.hasAttr("src")) {
                     continue;
@@ -73,6 +77,36 @@ public class XhamsterRipper extends AlbumRipper {
         waitForThreads();
     }
 
+    /**
+     * @todo prefix with uploader username
+     */
+    @Override
+    public String getAlbumTitle(URL url) throws MalformedURLException {
+        String title = HOST + "_";
+        Document doc = docs.get(url);;
+        if (doc == null) {
+            try {
+                doc = Http.url(url).header("User-Agent", USER_AGENT).referrer(url).cookies(Utils.getCookies(HOST)).get();
+                docs.put(url.toString(), doc);
+            } catch (IOException e) {
+                logger.error("Failed to download url=" + url + ": " + e.getMessage());
+            }
+        }
+        // Find username.
+        if (doc != null) {
+            for (Element link : doc.select("#galleryUser .item a")) {
+                title += link.text() + "_";
+                break;
+            }
+        }
+        String galleryLink = url.toExternalForm();
+        title += galleryLink
+            .replaceFirst("^http.*/photos/(?:gallery/([^?#:&]+)|view/([^-]+)-).*$", "$1$2")
+            .replace('/', '-')
+            .replace(".html", "");
+        return title;
+    }
+
     @Override
     public String getHost() {
         return HOST;
@@ -80,15 +114,14 @@ public class XhamsterRipper extends AlbumRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("^https?://([a-z0-9.]*?)xhamster\\.com/photos/gallery/([0-9]{1,})/.*\\.html");
-        Matcher m = p.matcher(url.toExternalForm());
-        if (m.matches()) {
-            return m.group(2);
-        }
-        throw new MalformedURLException(
+        String gid = url.toExternalForm().replaceFirst("^https?://(?:[a-z0-9.]*?)" + HOST + "\\.com/photos/(?:gallery/([0-9]{1,})/.*\\.html|view/([^-]+)-).*$", "$1$2");
+        if (gid.length() == 0) {
+            throw new MalformedURLException(
                 "Expected xhamster.com gallery formats: "
-                        + "xhamster.com/photos/gallery/#####/xxxxx..html"
-                        + " Got: " + url);
+                + "http://xhamster.com/photos/gallery/#####/xxxxx..html or http://xhamster.com/photos/view/####-####.html"
+                + " Got: " + url);
+        }
+        return gid;
     }
 
 }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -23,8 +23,6 @@ public class XhamsterRipper extends AlbumRipper {
 
     private static Pattern xhPattern = Pattern.compile("^https?://[a-z.]*" + HOST + "\\.com/photos/(?:gallery/([0-9]+).*|view/([0-9]+)-([0-9]+)\\.html(?:.*)?)$");
 
-    private HashMap<String, Document> docs = new HashMap<String, Document>();
-
     public XhamsterRipper(URL url) throws IOException {
         super(url);
     }
@@ -103,31 +101,6 @@ public class XhamsterRipper extends AlbumRipper {
         imageSrc = imageSrc.replaceAll("https?://p[0-9]*\\.", "https?://up.");
         imageSrc = imageSrc.replaceAll("_160\\.", "_1000.");
         return imageSrc;
-    }
-
-    private Document downloadAndSaveHTML(URL url) throws IOException {
-        String urlString = url.toExternalForm();
-        Document doc = docs.get(urlString);
-        if (doc == null) {
-            doc = Http.url(url).header("User-Agent", USER_AGENT).referrer(url).cookies(Utils.getCookies(HOST)).get();
-            docs.put(urlString, doc);
-        }
-        String filename = urlToFilename(url);
-        if (getWorkingDir() != null) {
-            Files.write(Paths.get(getWorkingDir().getCanonicalPath() + File.separator + filename), doc.toString().getBytes());
-        }
-        return doc;
-    }
-
-    private static String urlToFilename(URL url) {
-        String filename = url.toExternalForm().replaceFirst("^https?://.*/", "").replaceFirst("[#&:].*$", "");
-        if (filename.contains("?") && filename.contains(".")) {
-            int periodIdx = filename.lastIndexOf('.');
-            int questionMarkIdx = filename.indexOf('?');
-            String params = filename.substring(questionMarkIdx + 1).replaceAll("=", "-").replaceAll("&", "_");
-            filename = filename.substring(0, periodIdx) + "_" + params + filename.substring(periodIdx, questionMarkIdx);
-        }
-        return filename;
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -113,7 +113,9 @@ public class XhamsterRipper extends AlbumRipper {
             docs.put(urlString, doc);
         }
         String filename = urlToFilename(url);
-        Files.write(Paths.get(getWorkingDir().getCanonicalPath() + File.separator + filename), doc.toString().getBytes());
+        if (getWorkingDir() != null) {
+            Files.write(Paths.get(getWorkingDir().getCanonicalPath() + File.separator + filename), doc.toString().getBytes());
+        }
         return doc;
     }
 

--- a/src/main/java/com/rarchives/ripme/ui/ClipboardUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/ClipboardUtils.java
@@ -10,6 +10,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.rarchives.ripme.App.logger;
+
 public class ClipboardUtils {
     private static AutoripThread autoripThread = new AutoripThread();
     
@@ -33,6 +35,9 @@ public class ClipboardUtils {
                     .getDefaultToolkit()
                     .getSystemClipboard()
                     .getData(DataFlavor.stringFlavor);
+        } catch (IllegalStateException e) {
+            e.printStackTrace();
+            logger.error("Caught and recovered from IllegalStateException: " + e.getMessage());
         } catch (HeadlessException e) {
             e.printStackTrace();
         } catch (UnsupportedFlavorException e) {

--- a/src/main/java/com/rarchives/ripme/ui/QueueMenuMouseListener.java
+++ b/src/main/java/com/rarchives/ripme/ui/QueueMenuMouseListener.java
@@ -1,9 +1,12 @@
 package com.rarchives.ripme.ui;
 
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Clipboard;
 import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.Toolkit;
 import java.util.Enumeration;
 
 import javax.swing.AbstractAction;
@@ -16,13 +19,32 @@ import com.rarchives.ripme.utils.Utils;
 
 public class QueueMenuMouseListener extends MouseAdapter {
     private JPopupMenu popup = new JPopupMenu();
-    private Action removeSelected,
+    private Action copySelected,
+                   removeSelected,
                    clearQueue;
     private JList queueList;
     private DefaultListModel queueListModel;
 
     @SuppressWarnings("serial")
     public QueueMenuMouseListener() {
+
+        copySelected = new AbstractAction("Copy Selected") {
+            @Override
+            public void actionPerformed(ActionEvent ae) {
+                StringBuffer selection = new StringBuffer();
+                for (Object value : queueList.getSelectedValuesList()) {
+                    if (selection.length() > 0) {
+                        selection.append('\n');
+                    }
+                    selection.append(value);
+                }
+                StringSelection stringSelection = new StringSelection(selection.toString());
+                Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+                clipboard.setContents(stringSelection, stringSelection);
+                updateUI();
+            }
+        };
+        popup.add(copySelected);
 
         removeSelected = new AbstractAction("Remove Selected") {
             @Override

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -9,7 +9,9 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -69,6 +71,11 @@ public class Utils {
         } catch (Exception e) {
             logger.error("[!] Failed to load properties file from " + configFile, e);
         }
+    }
+
+    private static HashMap<String, HashMap<String, String>> cookieCache;
+    static {
+        cookieCache = new HashMap<String, HashMap<String, String>>();
     }
 
     /**
@@ -386,5 +393,22 @@ public class Utils {
             i = fullText.indexOf(start, j + finish.length());
         }
         return result;
+    }
+
+    public static Map<String, String> getCookies(String host) {
+        HashMap<String, String> domainCookies = cookieCache.get(host);
+        if (domainCookies == null) {
+            domainCookies = new HashMap<String, String>();
+            String cookiesConfig = getConfigString("cookies." + host, "");
+            for (String pair : cookiesConfig.split(" ")) {
+                pair = pair.trim();
+                if (pair.contains("=")) {
+                    String[] pieces = pair.split("=", 2);
+                    domainCookies.put(pieces[0], pieces[1]);
+                }
+            }
+            cookieCache.put(host, domainCookies);
+        }
+        return domainCookies;
     }
 }

--- a/src/main/resources/rip.properties
+++ b/src/main/resources/rip.properties
@@ -30,3 +30,7 @@ twitter.max_requests = 10
 clipboard.autorip = false
 
 download.save_order = true
+
+cookies.xhamster =
+# e.g. cookies.xhamster = USERNAME=sleaze UID=69696969 PWD=144354bc90792a91957df1ef962908c1 fingerprint=d65f704a8fef31b5327175e00f1eeb85
+

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BasicRippersTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BasicRippersTest.java
@@ -169,7 +169,7 @@ public class BasicRippersTest extends RippersTest {
     }
 
     public void testImgboxRip() throws IOException {
-        AbstractRipper ripper = new ImgboxRipper(new URL("http://imgbox.com/g/sEMHfsqx4w"));
+        AbstractRipper ripper = new ImgboxRipper(new URL("http://imgbox.com/g/z7Bj2FjxJX"));
         testRipper(ripper);
     }
 


### PR DESCRIPTION
- Eroshare naming now includes username, gallery-id, and gallery name.

e.g. for url=https://eroshare.com/aB12C3d uploaded by sample-user with
title="hello  there", the directory name will be:

    eroshare_sample-user_aB12C3d_hello-there

The raw HTML page is also now saved for eroshare.

- Refactored utility methods from XhamsterRipper into base AlbumRipper.