### PR TITLE
Added rippers for myhentaicomics.com, mymangacomics.com, myrule34.com, SinnerComics, buttsmithy

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ButtsmithyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ButtsmithyRipper.java
@@ -1,0 +1,88 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+import com.rarchives.ripme.utils.Utils;
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+public class ButtsmithyRipper extends AbstractHTMLRipper {
+
+    public ButtsmithyRipper(URL url) throws IOException {
+    super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "buttsmithy";
+    }
+
+    @Override
+    public String getDomain() {
+        return "buttsmithy.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("^https?://buttsmithy.com/archives/comic/([a-zA-Z0-9-]*)/?$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected imgur.com URL format: " +
+                        "https?://buttsmithy.com/archives/comic/ - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        return Http.url(url).get();
+    }
+
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        // Find next page
+        String nextUrl = "";
+        Element elem = doc.select("a.comic-nav-next").first();
+            if (elem == null) {
+                throw new IOException("No more pages");
+            }
+            String nextPage = elem.attr("href");
+            sleep(500);
+            return Http.url(nextPage).get();
+        }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<String>();
+        for (Element el : doc.select("meta[property=og:image]")) {
+            String imageSource = el.attr("content");
+            // Pattern p = Pattern.compile("/index.php/[a-zA-Z0-9_-]*\\?page=\\d");
+            // Matcher m = p.matcher(imageSource);
+            result.add(imageSource);
+        }
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+
+
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ButtsmithyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ButtsmithyRipper.java
@@ -45,7 +45,7 @@ public class ButtsmithyRipper extends AbstractHTMLRipper {
             return m.group(1);
         }
         throw new MalformedURLException("Expected buttsmithy.com URL format: " +
-                        "https?://buttsmithy.com/archives/comic/ - got " + url + " instead");
+                        "buttsmithy.com/archives/comic/ - got " + url + " instead");
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ButtsmithyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ButtsmithyRipper.java
@@ -44,7 +44,7 @@ public class ButtsmithyRipper extends AbstractHTMLRipper {
         if (m.matches()) {
             return m.group(1);
         }
-        throw new MalformedURLException("Expected imgur.com URL format: " +
+        throw new MalformedURLException("Expected buttsmithy.com URL format: " +
                         "https?://buttsmithy.com/archives/comic/ - got " + url + " instead");
     }
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ButtsmithyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ButtsmithyRipper.java
@@ -58,6 +58,8 @@ public class ButtsmithyRipper extends AbstractHTMLRipper {
     public Document getNextPage(Document doc) throws IOException {
         // Find next page
         String nextUrl = "";
+        // We use omic-nav-next to find the next page
+        // TODO Should comic-nav-next be in the default getNextPage? It seems pretty common
         Element elem = doc.select("a.comic-nav-next").first();
             if (elem == null) {
                 throw new IOException("No more pages");
@@ -71,6 +73,7 @@ public class ButtsmithyRipper extends AbstractHTMLRipper {
     @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<String>();
+        // We grab the image from meta because it's easier than trying to parse the rest of the page
         for (Element el : doc.select("meta[property=og:image]")) {
             String imageSource = el.attr("content");
             result.add(imageSource);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ButtsmithyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ButtsmithyRipper.java
@@ -63,6 +63,7 @@ public class ButtsmithyRipper extends AbstractHTMLRipper {
                 throw new IOException("No more pages");
             }
             String nextPage = elem.attr("href");
+            // Sleep for half a sec to avoid getting IP banned
             sleep(500);
             return Http.url(nextPage).get();
         }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ButtsmithyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ButtsmithyRipper.java
@@ -72,8 +72,6 @@ public class ButtsmithyRipper extends AbstractHTMLRipper {
         List<String> result = new ArrayList<String>();
         for (Element el : doc.select("meta[property=og:image]")) {
             String imageSource = el.attr("content");
-            // Pattern p = Pattern.compile("/index.php/[a-zA-Z0-9_-]*\\?page=\\d");
-            // Matcher m = p.matcher(imageSource);
             result.add(imageSource);
         }
         return result;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
@@ -19,7 +19,7 @@ import com.rarchives.ripme.utils.Http;
 
 public class ChanRipper extends AbstractHTMLRipper {
     public static List<ChanSite> explicit_domains = Arrays.asList(
-        new ChanSite(Arrays.asList("boards.4chan.org"),   Arrays.asList("4cdn.org", "is.4chan.org")),
+        new ChanSite(Arrays.asList("boards.4chan.org"),   Arrays.asList("4cdn.org", "is.4chan.org", "is2.4chan.org")),
         new ChanSite(Arrays.asList("archive.moe"),        Arrays.asList("data.archive.moe")),
         new ChanSite(Arrays.asList("4archive.org"),       Arrays.asList("imgur.com")),
         new ChanSite(Arrays.asList("archive.4plebs.org"), Arrays.asList("img.4plebs.org")),

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CheveretoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CheveretoRipper.java
@@ -52,7 +52,7 @@ public class CheveretoRipper extends AbstractHTMLRipper {
                 return m.group(1);
             }
             else if (m.matches() == false) {
-                Pattern pa = Pattern.compile("(?:https?://)?(?:www\\.)?[a-z1-9]*\\.[a-z1-9]*/([a-zA-Z1-9]*)/albums/?$");
+                Pattern pa = Pattern.compile("(?:https?://)?(?:www\\.)?[a-z1-9]*\\.[a-z1-9]*/([a-zA-Z1-9_-]*)/albums/?$");
                 Matcher ma = pa.matcher(url.toExternalForm());
                 if (ma.matches()) {
                     return ma.group(1);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CheveretoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CheveretoRipper.java
@@ -1,0 +1,81 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class CheveretoRipper extends AbstractHTMLRipper {
+
+    public CheveretoRipper(URL url) throws IOException {
+    super(url);
+    }
+
+    public static List<String> explicit_domains_1 = Arrays.asList("www.ezphotoshare.com", "hushpix.com");
+        @Override
+        public String getHost() {
+            String host = url.toExternalForm();
+            return host;
+        }
+
+        @Override
+        public String getDomain() {
+            String host = url.toExternalForm();
+            return host;
+        }
+
+        @Override
+        public boolean canRip(URL url) {
+            String url_name = url.toExternalForm();
+            if (explicit_domains_1.contains(url_name.split("/")[2]) == true) {
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public String getGID(URL url) throws MalformedURLException {
+            Pattern p = Pattern.compile("(?:https?://)?(?:www\\.)?[a-z1-9]*\\.[a-z1-9]*/album/([a-zA-Z1-9]*)/?$");
+            Matcher m = p.matcher(url.toExternalForm());
+            if (m.matches()) {
+                return m.group(1);
+            }
+            throw new MalformedURLException("Expected chevereto URL format: " +
+                            "site.domain/album/albumName - got " + url + " instead");
+        }
+
+        @Override
+        public Document getFirstPage() throws IOException {
+            // "url" is an instance field of the superclass
+            return Http.url(url).get();
+        }
+
+        @Override
+        public List<String> getURLsFromPage(Document doc) {
+            List<String> result = new ArrayList<String>();
+            for (Element el : doc.select("a.image-container > img")) {
+                    String imageSource = el.attr("src");
+                    imageSource = imageSource.replace(".md", "");
+                    result.add(imageSource);
+                }
+            return result;
+        }
+
+        @Override
+        public void downloadURL(URL url, int index) {
+            addURLToDownload(url, getPrefix(index));
+        }
+
+
+    }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EHentaiRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EHentaiRipper.java
@@ -38,7 +38,7 @@ public class EHentaiRipper extends AbstractHTMLRipper {
 
     // Current HTML document
     private Document albumDoc = null;
-    
+
     private static final Map<String,String> cookies = new HashMap<String,String>();
     static {
         cookies.put("nw", "1");
@@ -53,10 +53,10 @@ public class EHentaiRipper extends AbstractHTMLRipper {
     public String getHost() {
         return "e-hentai";
     }
-    
+
     @Override
     public String getDomain() {
-        return "g.e-hentai.org";
+        return "e-hentai.org";
     }
 
     public String getAlbumTitle(URL url) throws MalformedURLException {
@@ -79,18 +79,18 @@ public class EHentaiRipper extends AbstractHTMLRipper {
         Pattern p;
         Matcher m;
 
-        p = Pattern.compile("^.*g\\.e-hentai\\.org/g/([0-9]+)/([a-fA-F0-9]+)/$");
+        p = Pattern.compile("^https?://e-hentai\\.org/g/([0-9]+)/([a-fA-F0-9]+)/$");
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1) + "-" + m.group(2);
         }
 
         throw new MalformedURLException(
-                "Expected g.e-hentai.org gallery format: "
-                        + "http://g.e-hentai.org/g/####/####/"
+                "Expected e-hentai.org gallery format: "
+                        + "http://e-hentai.org/g/####/####/"
                         + " Got: " + url);
     }
-    
+
     /**
      * Attempts to get page, checks for IP ban, waits.
      * @param url
@@ -185,7 +185,7 @@ public class EHentaiRipper extends AbstractHTMLRipper {
 
     /**
      * Helper class to find and download images found on "image" pages
-     * 
+     *
      * Handles case when site has IP-banned the user.
      */
     private class EHentaiImageThread extends Thread {
@@ -204,7 +204,7 @@ public class EHentaiRipper extends AbstractHTMLRipper {
         public void run() {
             fetchImage();
         }
-        
+
         private void fetchImage() {
             try {
                 Document doc = getPageWithRetries(this.url);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -54,7 +54,8 @@ public class EightmusesRipper extends AbstractHTMLRipper {
             // Attempt to use album title as GID
             Element titleElement = getFirstPage().select("meta[name=description]").first();
             String title = titleElement.attr("content");
-            title = title.substring(title.lastIndexOf('/') + 1);
+            title = title.replace("A huge collection of free porn comics for adults. Read", "");
+            title = title.replace("online for free at 8muses.com", "");
             return getHost() + "_" + title.trim();
         } catch (IOException e) {
             // Fall back to default album naming convention

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
@@ -136,6 +136,9 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
     public void downloadURL(URL url, int index) {
         String url_string = url.toExternalForm();
         url_string = url_string.replace("%20", "_");
+        url_string = url_string.replace("%27", "");
+        url_string = url_string.replace("%28", "_");
+        url_string = url_string.replace("%29", "_");
         addURLToDownload(url, getPrefix(index), url_string.split("/")[6]);
     }
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
@@ -51,7 +51,7 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
             return ma.group(1);
         }
 
-        Pattern pat = Pattern.compile("^http://myhentaicomics.com/index.php/tag/([0-9]*)/?$");
+        Pattern pat = Pattern.compile("^http://myhentaicomics.com/index.php/tag/([0-9]*)/?([a-zA-Z%0-9+\\?=:]*)?$");
         Matcher mat = pat.matcher(url.toExternalForm());
         if (mat.matches()) {
             return mat.group(1);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
@@ -1,0 +1,98 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+import com.rarchives.ripme.utils.Utils;
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+public class MyhentaicomicsRipper extends AbstractHTMLRipper {
+
+    public MyhentaicomicsRipper(URL url) throws IOException {
+    super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "myhentaicomics";
+    }
+
+    @Override
+    public String getDomain() {
+        return "myhentaicomics.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("^https?://myhentaicomics.com/index.php/([a-zA-Z0-9-]*)$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected imgur.com URL format: " +
+                        "myhentaicomics.com/index.php/albumName - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        return Http.url(url).get();
+    }
+
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        // Find next page
+        String nextUrl = "";
+        // for (Element elem : doc.select("a.ui-icon-right").first()) {
+        Element elem = doc.select("a.ui-icon-right").first();
+            String nextPage = elem.attr("href");
+            Pattern p = Pattern.compile("/index.php/[a-zA-Z0-9_-]*\\?page=\\d");
+            Matcher m = p.matcher(nextPage);
+            if (m.matches()) {
+                nextUrl = "http://myhentaicomics.com" + m.group(0);
+                }
+            // }
+            if (nextUrl == "") {
+                throw new IOException("No more pages");
+            }
+            sleep(500);
+            return Http.url(nextUrl).get();
+        }
+
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<String>();
+        for (Element el : doc.select("img")) {
+            String imageSource = el.attr("src");
+            // We replace thumbs with resizes so we can the full sized images
+            imageSource = imageSource.replace("thumbs", "resizes");
+            if (imageSource != "http://myhentaicomics.com/themes/clean_canvas/images/logo4.png") {
+                result.add("http://myhentaicomics.com/" + imageSource);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+
+
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
@@ -44,13 +44,19 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
         if (m.matches()) {
             return m.group(1);
         }
-        else if (m.matches() == false) {
-            Pattern pa = Pattern.compile("^https?://myhentaicomics.com/index.php/search\\?q=([a-zA-Z0-9-]*)$");
-            Matcher ma = pa.matcher(url.toExternalForm());
-            if (ma.matches()) {
-                return ma.group(1);
-            }
+
+        Pattern pa = Pattern.compile("^https?://myhentaicomics.com/index.php/search\\?q=([a-zA-Z0-9-]*)$");
+        Matcher ma = pa.matcher(url.toExternalForm());
+        if (ma.matches()) {
+            return ma.group(1);
         }
+
+        Pattern pat = Pattern.compile("^http://myhentaicomics.com/index.php/tag/([0-9]*)/?$");
+        Matcher mat = pat.matcher(url.toExternalForm());
+        if (mat.matches()) {
+            return mat.group(1);
+        }
+
         throw new MalformedURLException("Expected myhentaicomics.com URL format: " +
                         "myhentaicomics.com/index.php/albumName - got " + url + " instead");
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
@@ -68,6 +68,7 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
             if (nextUrl == "") {
                 throw new IOException("No more pages");
             }
+            // Sleep for half a sec to avoid getting IP banned
             sleep(500);
             return Http.url(nextUrl).get();
         }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
@@ -79,9 +79,13 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
         List<String> result = new ArrayList<String>();
         for (Element el : doc.select("img")) {
             String imageSource = el.attr("src");
+            // This bool is here so we don't try and download the site logo
+            boolean b = imageSource.startsWith("http");
+            if (b == false) {
             // We replace thumbs with resizes so we can the full sized images
             imageSource = imageSource.replace("thumbs", "resizes");
             result.add("http://myhentaicomics.com/" + imageSource);
+            }
         }
         return result;
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
@@ -39,7 +39,7 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("^https?://myhentaicomics.com/index.php/([a-zA-Z0-9-]*)$");
+        Pattern p = Pattern.compile("^https?://myhentaicomics.com/index.php/([a-zA-Z0-9-]*)/?$");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
@@ -81,9 +81,7 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
             String imageSource = el.attr("src");
             // We replace thumbs with resizes so we can the full sized images
             imageSource = imageSource.replace("thumbs", "resizes");
-            if (imageSource != "http://myhentaicomics.com/themes/clean_canvas/images/logo4.png") {
-                result.add("http://myhentaicomics.com/" + imageSource);
-            }
+            result.add("http://myhentaicomics.com/" + imageSource);
         }
         return result;
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
@@ -44,7 +44,7 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
         if (m.matches()) {
             return m.group(1);
         }
-        throw new MalformedURLException("Expected imgur.com URL format: " +
+        throw new MalformedURLException("Expected myhentaicomics.com URL format: " +
                         "myhentaicomics.com/index.php/albumName - got " + url + " instead");
     }
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
@@ -45,7 +45,7 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
             return m.group(1);
         }
 
-        Pattern pa = Pattern.compile("^https?://myhentaicomics.com/index.php/search\\?q=([a-zA-Z0-9-]*)$");
+        Pattern pa = Pattern.compile("^https?://myhentaicomics.com/index.php/search\\?q=([a-zA-Z0-9-]*)([a-zA-Z0-9=&]*)?$");
         Matcher ma = pa.matcher(url.toExternalForm());
         if (ma.matches()) {
             return ma.group(1);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
@@ -81,6 +81,7 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
         }
 
 
+
     @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<String>();
@@ -127,7 +128,9 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
 
     @Override
     public void downloadURL(URL url, int index) {
-        addURLToDownload(url, getPrefix(index));
+        String url_string = url.toExternalForm();
+        url_string = url_string.replace("%20", "_");
+        addURLToDownload(url, getPrefix(index), url_string.split("/")[6]);
     }
 
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
@@ -58,7 +58,6 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
     public Document getNextPage(Document doc) throws IOException {
         // Find next page
         String nextUrl = "";
-        // for (Element elem : doc.select("a.ui-icon-right").first()) {
         Element elem = doc.select("a.ui-icon-right").first();
             String nextPage = elem.attr("href");
             Pattern p = Pattern.compile("/index.php/[a-zA-Z0-9_-]*\\?page=\\d");
@@ -66,7 +65,6 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
             if (m.matches()) {
                 nextUrl = "http://myhentaicomics.com" + m.group(0);
                 }
-            // }
             if (nextUrl == "") {
                 throw new IOException("No more pages");
             }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MymangacomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MymangacomicsRipper.java
@@ -1,0 +1,98 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+import com.rarchives.ripme.utils.Utils;
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+public class MymangacomicsRipper extends AbstractHTMLRipper {
+
+    public MymangacomicsRipper(URL url) throws IOException {
+    super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "mymangacomics";
+    }
+
+    @Override
+    public String getDomain() {
+        return "mymangacomics.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("^https?://mymangacomics.com/index.php/([a-zA-Z0-9-]*)$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected imgur.com URL format: " +
+                        "mymangacomics.com/index.php/albumName - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        return Http.url(url).get();
+    }
+
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        // Find next page
+        String nextUrl = "";
+        // for (Element elem : doc.select("a.ui-icon-right").first()) {
+        Element elem = doc.select("a.ui-icon-right").first();
+            String nextPage = elem.attr("href");
+            Pattern p = Pattern.compile("/index.php/[a-zA-Z0-9_-]*\\?page=\\d");
+            Matcher m = p.matcher(nextPage);
+            if (m.matches()) {
+                nextUrl = "http://mymangacomics.com" + m.group(0);
+                }
+            // }
+            if (nextUrl == "") {
+                throw new IOException("No more pages");
+            }
+            sleep(500);
+            return Http.url(nextUrl).get();
+        }
+
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<String>();
+        for (Element el : doc.select("img")) {
+            String imageSource = el.attr("src");
+            // We replace thumbs with resizes so we can the full sized images
+            imageSource = imageSource.replace("thumbs", "resizes");
+            if (imageSource != "http://mymangacomics.com/themes/clean_canvas/images/logo4.png") {
+                result.add("http://mymangacomics.com/" + imageSource);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+
+
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MymangacomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MymangacomicsRipper.java
@@ -68,6 +68,7 @@ public class MymangacomicsRipper extends AbstractHTMLRipper {
             if (nextUrl == "") {
                 throw new IOException("No more pages");
             }
+            // Sleep for half a sec to avoid getting IP banned
             sleep(500);
             return Http.url(nextUrl).get();
         }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MymangacomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MymangacomicsRipper.java
@@ -79,9 +79,10 @@ public class MymangacomicsRipper extends AbstractHTMLRipper {
         List<String> result = new ArrayList<String>();
         for (Element el : doc.select("img")) {
             String imageSource = el.attr("src");
-            // We replace thumbs with resizes so we can the full sized images
-            imageSource = imageSource.replace("thumbs", "resizes");
-            if (imageSource != "http://mymangacomics.com/themes/clean_canvas/images/logo4.png") {
+            // This bool is here so we don't try and download the site logo
+            boolean b = imageSource.startsWith("http");
+            if (b == false) {
+                imageSource = imageSource.replace("thumbs", "resizes");
                 result.add("http://mymangacomics.com/" + imageSource);
             }
         }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MymangacomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MymangacomicsRipper.java
@@ -44,7 +44,7 @@ public class MymangacomicsRipper extends AbstractHTMLRipper {
         if (m.matches()) {
             return m.group(1);
         }
-        throw new MalformedURLException("Expected imgur.com URL format: " +
+        throw new MalformedURLException("Expected mymangacomics.com URL format: " +
                         "mymangacomics.com/index.php/albumName - got " + url + " instead");
     }
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MymangacomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MymangacomicsRipper.java
@@ -58,7 +58,6 @@ public class MymangacomicsRipper extends AbstractHTMLRipper {
     public Document getNextPage(Document doc) throws IOException {
         // Find next page
         String nextUrl = "";
-        // for (Element elem : doc.select("a.ui-icon-right").first()) {
         Element elem = doc.select("a.ui-icon-right").first();
             String nextPage = elem.attr("href");
             Pattern p = Pattern.compile("/index.php/[a-zA-Z0-9_-]*\\?page=\\d");
@@ -66,7 +65,6 @@ public class MymangacomicsRipper extends AbstractHTMLRipper {
             if (m.matches()) {
                 nextUrl = "http://mymangacomics.com" + m.group(0);
                 }
-            // }
             if (nextUrl == "") {
                 throw new IOException("No more pages");
             }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/Myrule34Ripper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/Myrule34Ripper.java
@@ -44,7 +44,7 @@ public class Myrule34Ripper extends AbstractHTMLRipper {
         if (m.matches()) {
             return m.group(1);
         }
-        throw new MalformedURLException("Expected imgur.com URL format: " +
+        throw new MalformedURLException("Expected myrule34.com URL format: " +
                         "myrule34.com/index.php/albumName - got " + url + " instead");
     }
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/Myrule34Ripper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/Myrule34Ripper.java
@@ -79,9 +79,11 @@ public class Myrule34Ripper extends AbstractHTMLRipper {
         List<String> result = new ArrayList<String>();
         for (Element el : doc.select("img")) {
             String imageSource = el.attr("src");
+            // This bool is here so we don't try and download the site logo
+            boolean b = imageSource.startsWith("http");
+            if (b == false) {
             // We replace thumbs with resizes so we can the full sized images
             imageSource = imageSource.replace("thumbs", "resizes");
-            if (imageSource != "http://myrule34.com/themes/clean_canvas/images/logo4.png") {
                 result.add("http://myrule34.com/" + imageSource);
             }
         }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/Myrule34Ripper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/Myrule34Ripper.java
@@ -58,7 +58,6 @@ public class Myrule34Ripper extends AbstractHTMLRipper {
     public Document getNextPage(Document doc) throws IOException {
         // Find next page
         String nextUrl = "";
-        // for (Element elem : doc.select("a.ui-icon-right").first()) {
         Element elem = doc.select("a.ui-icon-right").first();
             String nextPage = elem.attr("href");
             Pattern p = Pattern.compile("/index.php/[a-zA-Z0-9_-]*\\?page=\\d");
@@ -66,7 +65,6 @@ public class Myrule34Ripper extends AbstractHTMLRipper {
             if (m.matches()) {
                 nextUrl = "http://myrule34.com" + m.group(0);
                 }
-            // }
             if (nextUrl == "") {
                 throw new IOException("No more pages");
             }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/Myrule34Ripper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/Myrule34Ripper.java
@@ -1,0 +1,98 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+import com.rarchives.ripme.utils.Utils;
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+public class Myrule34Ripper extends AbstractHTMLRipper {
+
+    public Myrule34Ripper(URL url) throws IOException {
+    super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "myrule34";
+    }
+
+    @Override
+    public String getDomain() {
+        return "myrule34.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("^https?://myrule34.com/index.php/([a-zA-Z0-9-]*)$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected imgur.com URL format: " +
+                        "myrule34.com/index.php/albumName - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        return Http.url(url).get();
+    }
+
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        // Find next page
+        String nextUrl = "";
+        // for (Element elem : doc.select("a.ui-icon-right").first()) {
+        Element elem = doc.select("a.ui-icon-right").first();
+            String nextPage = elem.attr("href");
+            Pattern p = Pattern.compile("/index.php/[a-zA-Z0-9_-]*\\?page=\\d");
+            Matcher m = p.matcher(nextPage);
+            if (m.matches()) {
+                nextUrl = "http://myrule34.com" + m.group(0);
+                }
+            // }
+            if (nextUrl == "") {
+                throw new IOException("No more pages");
+            }
+            sleep(500);
+            return Http.url(nextUrl).get();
+        }
+
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<String>();
+        for (Element el : doc.select("img")) {
+            String imageSource = el.attr("src");
+            // We replace thumbs with resizes so we can the full sized images
+            imageSource = imageSource.replace("thumbs", "resizes");
+            if (imageSource != "http://myrule34.com/themes/clean_canvas/images/logo4.png") {
+                result.add("http://myrule34.com/" + imageSource);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+
+
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/Myrule34Ripper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/Myrule34Ripper.java
@@ -68,6 +68,7 @@ public class Myrule34Ripper extends AbstractHTMLRipper {
             if (nextUrl == "") {
                 throw new IOException("No more pages");
             }
+            // Sleep for half a sec to avoid getting IP banned
             sleep(500);
             return Http.url(nextUrl).get();
         }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SinnercomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SinnercomicsRipper.java
@@ -45,7 +45,7 @@ public class SinnercomicsRipper extends AbstractHTMLRipper {
             return m.group(1);
         }
         throw new MalformedURLException("Expected sinnercomics.com URL format: " +
-                        "https://sinnercomics.com/comic/albumName - got " + url + " instead");
+                        "sinnercomics.com/comic/albumName - got " + url + " instead");
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SinnercomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SinnercomicsRipper.java
@@ -58,11 +58,13 @@ public class SinnercomicsRipper extends AbstractHTMLRipper {
     public Document getNextPage(Document doc) throws IOException {
         // Find next page
         String nextUrl = "";
+        // We use comic-nav-next to the find the next page
         Element elem = doc.select("a.comic-nav-next").first();
             if (elem == null) {
                 throw new IOException("No more pages");
             }
             String nextPage = elem.attr("href");
+            // Wait half a sec to avoid IP bans
             sleep(500);
             return Http.url(nextPage).get();
         }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SinnercomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SinnercomicsRipper.java
@@ -44,7 +44,7 @@ public class SinnercomicsRipper extends AbstractHTMLRipper {
         if (m.matches()) {
             return m.group(1);
         }
-        throw new MalformedURLException("Expected imgur.com URL format: " +
+        throw new MalformedURLException("Expected sinnercomics.com URL format: " +
                         "https://sinnercomics.com/comic/albumName - got " + url + " instead");
     }
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SinnercomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SinnercomicsRipper.java
@@ -1,0 +1,86 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+import com.rarchives.ripme.utils.Utils;
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+public class SinnercomicsRipper extends AbstractHTMLRipper {
+
+    public SinnercomicsRipper(URL url) throws IOException {
+    super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "sinnercomics";
+    }
+
+    @Override
+    public String getDomain() {
+        return "sinnercomics.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("^https?://sinnercomics.com/comic/([a-zA-Z0-9-]*)/?$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected imgur.com URL format: " +
+                        "https://sinnercomics.com/comic/albumName - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        return Http.url(url).get();
+    }
+
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        // Find next page
+        String nextUrl = "";
+        Element elem = doc.select("a.comic-nav-next").first();
+            if (elem == null) {
+                throw new IOException("No more pages");
+            }
+            String nextPage = elem.attr("href");
+            sleep(500);
+            return Http.url(nextPage).get();
+        }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<String>();
+        for (Element el : doc.select("img.alignnone")) {
+            String imageSource = el.attr("src");
+            result.add(imageSource);
+        }
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+
+
+}


### PR DESCRIPTION
I also added a ripper for Mymangacomics.com (Which is largely the same as myhentaicomics.com) and myrule34.com

I also added a ripper for sinnercomics.com

And a ripper for buttsmithy (This one seems to work but owning to the size of the buttsmithy comic (Over 400 pages) I can't check every page to be sure)

I also changed the domain and regex for the ehentai ripper, fixing issue [436](https://github.com/4pr0n/ripme/issues/436)

 8muse was changed to fix the issue with issue naming (The series name wasn't included in the folder name (Instead of series_whatever_issue_whatever it was just issue_whatever))

I added a subdomain to the 4chan bit of the chanripper to fix an issue with all images not ripping

I changed up the Chevereto a bit so you can now rip all the albums a user had posted pretty much closing issue [433](https://github.com/4pr0n/ripme/issues/433) ~~(Unless anyone knows a way to define more than one GID (An array maybe?))~~ but I still need to tweak how I'm calling `addURLToDownload`

---

@metaprime's summary:

Fixed ChanRipper for 4chan by adding another image host
Fixed EHentaiRipper for new URL format (removed `g.` subdomain)
Fixed album naming for EightmusesRipper

Added rippers for Buttsmithy, Chevereto, MyHentaiComics, MyMangaComics, MyRule34, and SinnerComics.