### PR TITLE
Added maven compiler plugin to more strictly use Java 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,15 @@
           </descriptorRefs>
         </configuration>
       </plugin>
+      <plugin>
+      	<groupId>org.apache.maven.plugins</groupId>
+      	<artifactId>maven-compiler-plugin</artifactId>
+      	<version>3.1</version>
+      	<configuration>
+      		<source>1.6</source>
+      		<target>1.6</target>
+      	</configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Added maven compiler plugin and set source and target version to 1.6 (to stop eclipse from bickering about @override on interface
implementations)

See https://github.com/4pr0n/ripme/pull/320#issuecomment-268801880