### PR TITLE
Fixed 8muses naming issue and removed catch for unthrown error

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -54,7 +54,8 @@ public class EightmusesRipper extends AbstractHTMLRipper {
             // Attempt to use album title as GID
             Element titleElement = getFirstPage().select("meta[name=description]").first();
             String title = titleElement.attr("content");
-            title = title.substring(title.lastIndexOf('/') + 1);
+            title = title.replace("A huge collection of free porn comics for adults. Read", "");
+            title = title.replace("online for free at 8muses.com", "");
             return getHost() + "_" + title.trim();
         } catch (IOException e) {
             // Fall back to default album naming convention
@@ -122,13 +123,9 @@ public class EightmusesRipper extends AbstractHTMLRipper {
                     }
                     try {
                         logger.info("Retrieving full-size image location from " + parentHref);
-                        Thread.sleep(1000);
                         image = getFullSizeImage(parentHref);
                     } catch (IOException e) {
                         logger.error("Failed to get full-size image from " + parentHref);
-                        continue;
-                    } catch (InterruptedException e) {
-                        logger.error("Interrupted while getting full-size image from " + parentHref);
                         continue;
                     }
                 }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -40,7 +40,7 @@ public class EightmusesRipper extends AbstractHTMLRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("^https?://(www\\.)?8muses\\.com/index/category/([a-zA-Z0-9\\-_]+).*$");
+        Pattern p = Pattern.compile("^https?://(www\\.)?8muses\\.com/comix/album/([a-zA-Z0-9\\-_]+).*$");
         Matcher m = p.matcher(url.toExternalForm());
         if (!m.matches()) {
             throw new MalformedURLException("Expected URL format: http://www.8muses.com/index/category/albumname, got: " + url);


### PR DESCRIPTION
This commit fixes the naming issue with 8muse comic issues (A comic with the name format of Comic_name/issue_X would be written to a folder called issue_X instead of comic_name_issue_X)

Also fixes https://github.com/4pr0n/ripme/issues/461