### PR TITLE
Added work around for sinnercomics naming bug

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SinnercomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SinnercomicsRipper.java
@@ -74,6 +74,7 @@ public class SinnercomicsRipper extends AbstractHTMLRipper {
         List<String> result = new ArrayList<String>();
         for (Element el : doc.select("meta[property=og:image]")) {
             String imageSource = el.attr("content");
+            imageSource = imageSource.replace(" alt=", "");
             result.add(imageSource);
         }
         return result;


### PR DESCRIPTION
This PR removes the string " alt=" from all of sinnercomics image urls to work around a bug with the site (For some reason some image urls have a trailing " alt=")