### PR TITLE
Wordpress comic ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -22,7 +22,8 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
     super(url);
     }
 
-    public static List<String> explicit_domains = Arrays.asList("www.totempole666.com", "buttsmithy.com", "themonsterunderthebed.net");
+    public static List<String> explicit_domains = Arrays.asList("www.totempole666.com",
+    "buttsmithy.com", "themonsterunderthebed.net", "prismblush.com");
         @Override
         public String getHost() {
             String host = url.toExternalForm().split("/")[2];
@@ -57,6 +58,12 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
                     return true;
                 }
 
+                Pattern prismblushPat = Pattern.compile("https?://prismblush.com/comic/([a-zA-Z0-9_-]*)/?$");
+                Matcher prismblushMat = prismblushPat.matcher(url.toExternalForm());
+                if (prismblushMat.matches()) {
+                    return true;
+                }
+
             }
             return false;
         }
@@ -79,6 +86,12 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             Matcher theMonsterUnderTheBedMat = theMonsterUnderTheBedPat.matcher(url.toExternalForm());
             if (theMonsterUnderTheBedMat.matches()) {
                 return "themonsterunderthebed.net_TheMonsterUnderTheBed";
+            }
+
+            Pattern prismblushPat = Pattern.compile("https?://prismblush.com/comic/([a-zA-Z0-9_-]*)/?$");
+            Matcher prismblushMat = prismblushPat.matcher(url.toExternalForm());
+            if (prismblushMat.matches()) {
+                return "prismblush.com_" + prismblushMat.group(1).replaceAll("-pg-\\d+", "");
             }
 
             return super.getAlbumTitle(url);
@@ -108,7 +121,8 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             Element elem = null;
             if (explicit_domains.contains("www.totempole666.com") == true
             || explicit_domains.contains("buttsmithy.com") == true
-            || explicit_domains.contains("themonsterunderthebed.net")) {
+            || explicit_domains.contains("themonsterunderthebed.net")
+            || explicit_domains.contains("prismblush.com")) {
                 elem = doc.select("a.comic-nav-next").first();
                 if (elem == null) {
                     throw new IOException("No more pages");
@@ -128,7 +142,8 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             List<String> result = new ArrayList<String>();
             if (explicit_domains.contains("www.totempole666.com") == true
             || explicit_domains.contains("buttsmithy.com") == true
-            || explicit_domains.contains("themonsterunderthebed.net")) {
+            || explicit_domains.contains("themonsterunderthebed.net")
+            || explicit_domains.contains("prismblush.com")) {
                 Element elem = doc.select("div.comic-table > div#comic > a > img").first();
                 // If doc is the last page in the comic then elem.attr("src") returns null
                 // because there is no link <a> to the next page

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -1,0 +1,122 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class WordpressComicRipper extends AbstractHTMLRipper {
+
+    public WordpressComicRipper(URL url) throws IOException {
+    super(url);
+    }
+
+    public static List<String> explicit_domains = Arrays.asList("www.totempole666.com");
+        @Override
+        public String getHost() {
+            String host = url.toExternalForm().split("/")[2];
+            return host;
+        }
+
+        @Override
+        public String getDomain() {
+            String host = url.toExternalForm().split("/")[2];
+            return host;
+        }
+
+        @Override
+        public boolean canRip(URL url) {
+            String url_name = url.toExternalForm();
+            if (explicit_domains.contains(url_name.split("/")[2]) == true) {
+                Pattern totempole666Pat = Pattern.compile("https?://www\\.totempole666.com\\/comic/([a-zA-Z0-9_-]*)/?$");
+                Matcher totempole666Mat = totempole666Pat.matcher(url.toExternalForm());
+                if (totempole666Mat.matches()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public String getAlbumTitle(URL url) throws MalformedURLException {
+            Pattern totempole666Pat = Pattern.compile("(?:https?://)?(?:www\\.)?totempole666.com\\/comic/([a-zA-Z0-9_-]*)/?$");
+            Matcher totempole666Mat = totempole666Pat.matcher(url.toExternalForm());
+            if (totempole666Mat.matches()) {
+                return getHost() + "_" + "The_cummoner";
+            }
+            return super.getAlbumTitle(url);
+        }
+
+
+        @Override
+        public String getGID(URL url) throws MalformedURLException {
+            String url_name = url.toExternalForm();
+            // We shouldn't need to return any GID
+            if (explicit_domains.contains(url_name.split("/")[2]) == true) {
+                return "";
+            }
+            throw new MalformedURLException("Expected chevereto URL format: " +
+                            "site.domain/album/albumName or site.domain/username/albums- got " + url + " instead");
+        }
+
+        @Override
+        public Document getFirstPage() throws IOException {
+            // "url" is an instance field of the superclass
+            return Http.url(url).get();
+        }
+
+        @Override
+        public Document getNextPage(Document doc) throws IOException {
+            // Find next page
+            String nextPage = "";
+            Element elem = null;
+            if (explicit_domains.contains("www.totempole666.com") == true) {
+                elem = doc.select("a.comic-nav-next").first();
+                if (elem == null) {
+                    throw new IOException("No more pages");
+                }
+                nextPage = elem.attr("href");
+            }
+                if (nextPage == "") {
+                    throw new IOException("No more pages");
+                }
+                else {
+                    return Http.url(nextPage).get();
+                }
+            }
+
+        @Override
+        public List<String> getURLsFromPage(Document doc) {
+            List<String> result = new ArrayList<String>();
+            if (explicit_domains.contains("www.totempole666.com") == true) {
+                logger.info("The domain is www.totempole666.com");
+                Element elem = doc.select("div.comic-table > div#comic > a > img").first();
+                // If doc is the last page in the comic then elem.attr("src") returns null
+                // because there is no link <a> to the next page
+                if (elem == null) {
+                    logger.debug("Got last page in totempole666 comic");
+                    elem = doc.select("div.comic-table > div#comic > img").first();
+                }
+                result.add(elem.attr("src"));
+            }
+            return result;
+        }
+
+        @Override
+        public void downloadURL(URL url, int index) {
+            addURLToDownload(url, getPrefix(index));
+        }
+
+
+    }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -22,7 +22,7 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
     super(url);
     }
 
-    public static List<String> explicit_domains = Arrays.asList("www.totempole666.com", "buttsmithy.com");
+    public static List<String> explicit_domains = Arrays.asList("www.totempole666.com", "buttsmithy.com", "themonsterunderthebed.net");
         @Override
         public String getHost() {
             String host = url.toExternalForm().split("/")[2];
@@ -51,6 +51,12 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
                     return true;
                 }
 
+                Pattern theMonsterUnderTheBedPat = Pattern.compile("https?://themonsterunderthebed.net/\\?comic=([a-zA-Z0-9_-]*)/?$");
+                Matcher theMonsterUnderTheBedMat = theMonsterUnderTheBedPat.matcher(url.toExternalForm());
+                if (theMonsterUnderTheBedMat.matches()) {
+                    return true;
+                }
+
             }
             return false;
         }
@@ -68,6 +74,13 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             if (buttsmithyMat.matches()) {
                 return "totempole666.com" + "_" + "Alfie";
             }
+
+            Pattern theMonsterUnderTheBedPat = Pattern.compile("https?://themonsterunderthebed.net/?comic=([a-zA-Z0-9_-])/?$");
+            Matcher theMonsterUnderTheBedMat = theMonsterUnderTheBedPat.matcher(url.toExternalForm());
+            if (theMonsterUnderTheBedMat.matches()) {
+                return "themonsterunderthebed.net_TheMonsterUnderTheBed";
+            }
+
             return super.getAlbumTitle(url);
         }
 
@@ -93,7 +106,9 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             // Find next page
             String nextPage = "";
             Element elem = null;
-            if (explicit_domains.contains("www.totempole666.com") == true || explicit_domains.contains("buttsmithy.com") == true) {
+            if (explicit_domains.contains("www.totempole666.com") == true
+            || explicit_domains.contains("buttsmithy.com") == true
+            || explicit_domains.contains("themonsterunderthebed.net")) {
                 elem = doc.select("a.comic-nav-next").first();
                 if (elem == null) {
                     throw new IOException("No more pages");
@@ -111,7 +126,9 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
         @Override
         public List<String> getURLsFromPage(Document doc) {
             List<String> result = new ArrayList<String>();
-            if (explicit_domains.contains("www.totempole666.com") == true || explicit_domains.contains("buttsmithy.com") == true) {
+            if (explicit_domains.contains("www.totempole666.com") == true
+            || explicit_domains.contains("buttsmithy.com") == true
+            || explicit_domains.contains("themonsterunderthebed.net")) {
                 Element elem = doc.select("div.comic-table > div#comic > a > img").first();
                 // If doc is the last page in the comic then elem.attr("src") returns null
                 // because there is no link <a> to the next page

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -69,13 +69,13 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
                 return "totempole666.com" + "_" + "The_cummoner";
             }
 
-            Pattern buttsmithyPat = Pattern.compile("https?://buttsmithy.com/archives/comic/([a-zA-Z0-9_-])/?$");
+            Pattern buttsmithyPat = Pattern.compile("https?://buttsmithy.com/archives/comic/([a-zA-Z0-9_-]*)/?$");
             Matcher buttsmithyMat = buttsmithyPat.matcher(url.toExternalForm());
             if (buttsmithyMat.matches()) {
-                return "totempole666.com" + "_" + "Alfie";
+                return "buttsmithy.com" + "_" + "Alfie";
             }
 
-            Pattern theMonsterUnderTheBedPat = Pattern.compile("https?://themonsterunderthebed.net/?comic=([a-zA-Z0-9_-])/?$");
+            Pattern theMonsterUnderTheBedPat = Pattern.compile("https?://themonsterunderthebed.net/?comic=([a-zA-Z0-9_-]*)/?$");
             Matcher theMonsterUnderTheBedMat = theMonsterUnderTheBedPat.matcher(url.toExternalForm());
             if (theMonsterUnderTheBedMat.matches()) {
                 return "themonsterunderthebed.net_TheMonsterUnderTheBed";

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -22,7 +22,7 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
     super(url);
     }
 
-    public static List<String> explicit_domains = Arrays.asList("www.totempole666.com");
+    public static List<String> explicit_domains = Arrays.asList("www.totempole666.com", "buttsmithy.com");
         @Override
         public String getHost() {
             String host = url.toExternalForm().split("/")[2];
@@ -39,11 +39,18 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
         public boolean canRip(URL url) {
             String url_name = url.toExternalForm();
             if (explicit_domains.contains(url_name.split("/")[2]) == true) {
-                Pattern totempole666Pat = Pattern.compile("https?://www\\.totempole666.com\\/comic/([a-zA-Z0-9_-]*)/?$");
+                Pattern totempole666Pat = Pattern.compile("https?://www\\.totempole666.com/comic/([a-zA-Z0-9_-]*)/?$");
                 Matcher totempole666Mat = totempole666Pat.matcher(url.toExternalForm());
                 if (totempole666Mat.matches()) {
                     return true;
                 }
+
+                Pattern buttsmithyPat = Pattern.compile("https?://buttsmithy.com/archives/comic/([a-zA-Z0-9_-]*)/?$");
+                Matcher buttsmithyMat = buttsmithyPat.matcher(url.toExternalForm());
+                if (buttsmithyMat.matches()) {
+                    return true;
+                }
+
             }
             return false;
         }
@@ -53,7 +60,13 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             Pattern totempole666Pat = Pattern.compile("(?:https?://)?(?:www\\.)?totempole666.com\\/comic/([a-zA-Z0-9_-]*)/?$");
             Matcher totempole666Mat = totempole666Pat.matcher(url.toExternalForm());
             if (totempole666Mat.matches()) {
-                return getHost() + "_" + "The_cummoner";
+                return "totempole666.com" + "_" + "The_cummoner";
+            }
+
+            Pattern buttsmithyPat = Pattern.compile("https?://buttsmithy.com/archives/comic/([a-zA-Z0-9_-])/?$");
+            Matcher buttsmithyMat = buttsmithyPat.matcher(url.toExternalForm());
+            if (buttsmithyMat.matches()) {
+                return "totempole666.com" + "_" + "Alfie";
             }
             return super.getAlbumTitle(url);
         }
@@ -66,8 +79,7 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             if (explicit_domains.contains(url_name.split("/")[2]) == true) {
                 return "";
             }
-            throw new MalformedURLException("Expected chevereto URL format: " +
-                            "site.domain/album/albumName or site.domain/username/albums- got " + url + " instead");
+            throw new MalformedURLException("You should never see this error message");
         }
 
         @Override
@@ -81,7 +93,7 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             // Find next page
             String nextPage = "";
             Element elem = null;
-            if (explicit_domains.contains("www.totempole666.com") == true) {
+            if (explicit_domains.contains("www.totempole666.com") == true || explicit_domains.contains("buttsmithy.com") == true) {
                 elem = doc.select("a.comic-nav-next").first();
                 if (elem == null) {
                     throw new IOException("No more pages");
@@ -99,8 +111,7 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
         @Override
         public List<String> getURLsFromPage(Document doc) {
             List<String> result = new ArrayList<String>();
-            if (explicit_domains.contains("www.totempole666.com") == true) {
-                logger.info("The domain is www.totempole666.com");
+            if (explicit_domains.contains("www.totempole666.com") == true || explicit_domains.contains("buttsmithy.com") == true) {
                 Element elem = doc.select("div.comic-table > div#comic > a > img").first();
                 // If doc is the last page in the comic then elem.attr("src") returns null
                 // because there is no link <a> to the next page


### PR DESCRIPTION
I added a generic wordpress comic ripper that should be able to rip most wordpress webcomic sites with little modification (similar to what chanRipper does for chans).

Test links for the 4 currently support sites

http://buttsmithy.com/archives/comic/p1

http://www.totempole666.com/comic/first-time-for-everything-00-cover/

http://themonsterunderthebed.net/?comic=test-post

http://prismblush.com/comic/troll-toll-pg-00/

http://prismblush.com/comic/my-debut-pg-01/