### PR TITLE
Fixed deviantArt ripping

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -53,7 +53,7 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
     public boolean hasDescriptionSupport() {
 		return false;
     }
-    public String getDescription(String page) throws IOException {
+    public String[] getDescription(String url,Document page) throws IOException {
     	throw new IOException("getDescription not implemented"); // Do I do this or make an abstract function?
     }
     public int descSleepTime() {
@@ -95,15 +95,16 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
                     logger.debug("Found description link(s) from " + doc.location());
             		for (String textURL : textURLs) {
             			if (isStopped()) {
+
             				break;
             			}
             			textindex += 1;
             			logger.debug("Getting description from " + textURL);
                         sleep(descSleepTime());
-            			String tempDesc = getDescription(textURL);
+            			String[] tempDesc = getDescription(textURL,doc);
             			if (tempDesc != null) {
-            			    logger.debug("Got description: " + tempDesc);
-            				saveText(new URL(textURL), "", tempDesc, textindex);
+            			    logger.debug("Got description from " + textURL);
+            				saveText(new URL(textURL), "", tempDesc[0], textindex,tempDesc[1]);
             			}
             		}
             	}
@@ -130,18 +131,21 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
         waitForThreads();
     }
     public boolean saveText(URL url, String subdirectory, String text, int index) {
-        // Not the best for some cases, like FurAffinity. Overridden there.
-        try {
-            stopCheck();
-        } catch (IOException e) {
-            return false;
-        }
         String saveAs = url.toExternalForm();
         saveAs = saveAs.substring(saveAs.lastIndexOf('/')+1);
         if (saveAs.indexOf('?') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('?')); }
         if (saveAs.indexOf('#') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('#')); }
         if (saveAs.indexOf('&') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('&')); }
         if (saveAs.indexOf(':') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf(':')); }
+        return saveText(url,subdirectory,text,index,saveAs);
+    }
+    public boolean saveText(URL url, String subdirectory, String text, int index, String fileName) {
+        // Not the best for some cases, like FurAffinity. Overridden there.
+        try {
+            stopCheck();
+        } catch (IOException e) {
+            return false;
+        }
         File saveFileAs;
         try {
             if (!subdirectory.equals("")) { // Not sure about this part
@@ -153,7 +157,7 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
                     + subdirectory
                     + File.separator
                     + getPrefix(index)
-                    + saveAs
+                    + fileName
                     + ".txt");
             // Write the file
             FileOutputStream out = (new FileOutputStream(saveFileAs));

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -142,6 +142,7 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
     }
     public String fileNameFromURL(URL url) {
         String saveAs = url.toExternalForm();
+		if (saveAs.substring(saveAs.length() - 1) == "/") { saveAs = saveAs.substring(0,saveAs.length() - 1) ;}
         saveAs = saveAs.substring(saveAs.lastIndexOf('/')+1);
         if (saveAs.indexOf('?') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('?')); }
         if (saveAs.indexOf('#') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('#')); }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
@@ -180,9 +180,9 @@ public class DeviantartRipper extends AbstractHTMLRipper {
     @Override
     public List<String> getDescriptionsFromPage(Document page) {
         List<String> textURLs = new ArrayList<String>();
-
         // Iterate over all thumbnails
-        for (Element thumb : page.select("div.zones-container a.thumb")) {
+        for (Element thumb : page.select("div.zones-container span.thumb")) {
+            logger.info(thumb.attr("href"));
             if (isStopped()) {
                 break;
             }
@@ -191,6 +191,7 @@ public class DeviantartRipper extends AbstractHTMLRipper {
                 continue; // a.thumbs to other albums are invisible
             }
             textURLs.add(thumb.attr("href"));
+
         }
         return textURLs;
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
@@ -363,7 +363,7 @@ public class DeviantartRipper extends AbstractHTMLRipper {
             if (els.size() > 0) {
                 // Full-size image
                 String downloadLink = els.get(0).attr("href");
-                logger.info("Found download page: " + downloadLink);
+                logger.info("Found download button link: " + downloadLink);
                 HttpURLConnection con = (HttpURLConnection) new URL(downloadLink).openConnection();
                 con.setRequestProperty("Referer",this.url.toString());
                 String cookieString = "";
@@ -376,10 +376,11 @@ public class DeviantartRipper extends AbstractHTMLRipper {
                 con.setInstanceFollowRedirects(true);
                 con.connect();
                 int code = con.getResponseCode();
-                String location = con.getHeaderField("Location");
+                String location = con.getURL().toString();
                 con.disconnect();
                 if (location.contains("//orig")) {
                     fsimage = location;
+                    logger.info("Found image download: " + location);
                 }
             }
             if (fsimage != null) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
@@ -201,14 +201,15 @@ public class DeviantartRipper extends AbstractHTMLRipper {
         if (isThisATest()) {
             return null;
         }
-        Elements nextButtons = page.select("li.next > a");
+        Elements nextButtons = page.select("link[rel=\"next\"]");
         if (nextButtons.size() == 0) {
-            throw new IOException("No next page found");
+            if (page.select("link[rel=\"prev\"]").size() == 0) {
+                throw new IOException("No next page found");
+            } else {
+                throw new IOException("Hit end of pages");
+            }
         }
         Element a = nextButtons.first();
-        if (a.hasClass("disabled")) {
-            throw new IOException("Hit end of pages");
-        }
         String nextPage = a.attr("href");
         if (nextPage.startsWith("/")) {
             nextPage = "http://" + this.url.getHost() + nextPage;
@@ -306,7 +307,7 @@ public class DeviantartRipper extends AbstractHTMLRipper {
             if (fullSize == null) {
                 return new String[] {Jsoup.clean(ele.html().replaceAll("\\\\n", System.getProperty("line.separator")), "", Whitelist.none(), new Document.OutputSettings().prettyPrint(false))};
             }
-            fullSize = fullSize.substring(0,fullSize.lastIndexOf("."));
+            fullSize = fullSize.substring(0, fullSize.lastIndexOf("."));
             return new String[] {Jsoup.clean(ele.html().replaceAll("\\\\n", System.getProperty("line.separator")), "", Whitelist.none(), new Document.OutputSettings().prettyPrint(false)),fullSize};
             // TODO Make this not make a newline if someone just types \n into the description.
         } catch (IOException ioe) {


### PR DESCRIPTION
Uses the data-super-full-img attribute of thumbnails as first attempt to
get a full image URL. If that doesn't work (as is the case with mature
items), the JSON is used. thumbToFull is still broken in this commit,
but shouldn't be needed.

EDIT: Sorry, description ripping doesn't work. I'll submit a pull request when that's fixed.