### PR TITLE
Fixed ssl errro with ep.xhamster domain

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -53,6 +53,11 @@ public class XhamsterRipper extends AlbumRipper {
                 image = image.replaceAll(
                         "_160\\.",
                         "_1000.");
+                // Xhamster has shitty cert management and uses the wrong cert for their ep.xhamster Domain
+                // so we change all https requests to http
+                image = image.replaceAll(
+                            "https://",
+                            "http");
                 index += 1;
                 String prefix = "";
                 if (Utils.getConfigBoolean("download.save_order", true)) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -50,6 +50,9 @@ public class XhamsterRipper extends AlbumRipper {
                         "https://upt.xhcdn\\.",
                         "http://up.xhamster.");
                 image = image.replaceAll("ept\\.xhcdn", "ep.xhamster");
+                image = image.replaceAll(
+                        "_160\\.",
+                        "_1000.");
                 // Xhamster has shitty cert management and uses the wrong cert for their ep.xhamster Domain
                 // so we change all https requests to http
                 image = image.replaceAll(

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -50,14 +50,11 @@ public class XhamsterRipper extends AlbumRipper {
                         "https://upt.xhcdn\\.",
                         "http://up.xhamster.");
                 image = image.replaceAll("ept\\.xhcdn", "ep.xhamster");
-                image = image.replaceAll(
-                        "_160\\.",
-                        "_1000.");
                 // Xhamster has shitty cert management and uses the wrong cert for their ep.xhamster Domain
                 // so we change all https requests to http
                 image = image.replaceAll(
                             "https://",
-                            "http");
+                            "http://");
                 index += 1;
                 String prefix = "";
                 if (Utils.getConfigBoolean("download.save_order", true)) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -45,6 +45,7 @@ public class XhamsterRipper extends AlbumRipper {
                     continue;
                 }
                 String image = thumb.attr("src");
+                // replace thumbnail urls with the urls to the full sized images
                 image = image.replaceAll(
                         "https://upt.xhcdn\\.",
                         "http://up.xhamster.");


### PR DESCRIPTION
downloading images from the ep.xhamster.com domain no longer errors out. 