### PR TITLE
MainWindow.java : Select Save Directory Crash Fix

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -709,6 +709,7 @@ public class MainWindow implements Runnable, RipStatusHandler {
         configSaveDirButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent arg0) {
+                UIManager.put("FileChooser.useSystemExtensionHiding", false);
                 JFileChooser jfc = new JFileChooser(Utils.getWorkingDirectory());
                 jfc.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
                 int returnVal = jfc.showDialog(null, "select directory");


### PR DESCRIPTION
Fixes bug in Java that arose in Windows 10 Creator Update.

Caused the user to be unable to select directory with Windows Look & Feel enabled due to crashing. Disabling System Extension Hiding is currently the workaround suggested by Java devs.

See here: https://bugs.openjdk.java.net/browse/JDK-8179014