### PR TITLE
@SilhouetteTR #173: AbstractHTMLRipper and Utils improvements

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -67,8 +67,11 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
         sendUpdate(STATUS.LOADING_RESOURCE, this.url.toExternalForm());
         Document doc = getFirstPage();
 
+        boolean first = true;
+        
         while (doc != null) {
             List<String> imageURLs = getURLsFromPage(doc);
+
             // Remove all but 1 image
             if (isThisATest()) {
                 while (imageURLs.size() > 1) {
@@ -76,8 +79,15 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
                 }
             }
 
+            //if (imageURLs.size() == 0) {
             if (imageURLs.size() == 0) {
-                throw new IOException("No images found at " + doc.location());
+            	if (first) {
+            		throw new IOException("No images found at " + doc.location());
+            	}
+            	else {
+            		logger.info("No images in page...");
+            		break;
+            	}
             }
 
             for (String imageURL : imageURLs) {
@@ -120,6 +130,8 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
                 logger.info("Can't get next page: " + e.getMessage());
                 break;
             }
+            
+            first = false;
         }
 
         // If they're using a thread pool, wait for it.

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -129,6 +129,11 @@ public class Utils {
         }
         config.addProperty(key, list);
     }
+    
+    public static void clearConfigProperty(String key)
+    {
+    	config.clearProperty(key);
+    }
 
     public static void saveConfig() {
         try {


### PR DESCRIPTION
* Modified AbstractHTMLRipper.java so that "no images found" IOException is thrown only for the 1st page. The rest will just log and break out of the while loop.
* Added clearConfigProperty(...) to Utils.java