### PR TITLE
Convert GIFV links to GIF.

### DIFF
--- a/src/main/java/com/rarchives/ripme/utils/RipUtils.java
+++ b/src/main/java/com/rarchives/ripme/utils/RipUtils.java
@@ -104,11 +104,12 @@ public class RipUtils {
         }
 
         // Direct link to image
-        p = Pattern.compile("(https?://[a-zA-Z0-9\\-\\.]+\\.[a-zA-Z]{2,3}(/\\S*)\\.(jpg|jpeg|gif|png|mp4)(\\?.*)?)");
+        p = Pattern.compile("(https?://[a-zA-Z0-9\\-\\.]+\\.[a-zA-Z]{2,3}(/\\S*)\\.(jpg|jpeg|gif|gifv|png|mp4)(\\?.*)?)");
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             try {
-                URL singleURL = new URL(m.group(1));
+                String u = m.group(1).replace(".gifv",".gif");
+                URL singleURL = new URL(u);
                 logger.debug("Found single URL: " + singleURL);
                 result.add(singleURL);
                 return result;


### PR DESCRIPTION
Adds support for GIFV links from imgur by replacing the .gifv extension to .gif.

Because not all GIFVs will have an MP4 alternative, we stick to GIF to maintain compatibility, otherwise change .gif on line 111 to .mp4 to try and download the mp4 version of the gif.