### PR TITLE
Removed public modifier for methods on interfaces because it is redundant

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/RipperInterface.java
+++ b/src/main/java/com/rarchives/ripme/ripper/RipperInterface.java
@@ -9,10 +9,17 @@ import java.net.URL;
  * Oh well, here's to encapsulation and abstraction! (raises glass)
  */
 public interface RipperInterface {
-    public void rip() throws IOException;
-    public boolean canRip(URL url);
-    public URL sanitizeURL(URL url) throws MalformedURLException;
-    public void setWorkingDir(URL url) throws IOException;
-    public String getHost();
-    public String getGID(URL url) throws MalformedURLException;
+
+    void rip() throws IOException;
+
+    boolean canRip(URL url);
+
+    URL sanitizeURL(URL url) throws MalformedURLException;
+
+    void setWorkingDir(URL url) throws IOException;
+
+    String getHost();
+
+    String getGID(URL url) throws MalformedURLException;
+
 }

--- a/src/main/java/com/rarchives/ripme/ripper/RipperInterface.java
+++ b/src/main/java/com/rarchives/ripme/ripper/RipperInterface.java
@@ -9,17 +9,10 @@ import java.net.URL;
  * Oh well, here's to encapsulation and abstraction! (raises glass)
  */
 public interface RipperInterface {
-
     void rip() throws IOException;
-
     boolean canRip(URL url);
-
     URL sanitizeURL(URL url) throws MalformedURLException;
-
     void setWorkingDir(URL url) throws IOException;
-
     String getHost();
-
     String getGID(URL url) throws MalformedURLException;
-
 }

--- a/src/main/java/com/rarchives/ripme/ui/RipStatusHandler.java
+++ b/src/main/java/com/rarchives/ripme/ui/RipStatusHandler.java
@@ -1,14 +1,12 @@
-
 package com.rarchives.ripme.ui;
 
 import com.rarchives.ripme.ripper.AbstractRipper;
 
 /**
- *
  * @author Mads
  */
 public interface RipStatusHandler {
 
-    public void update(AbstractRipper ripper, RipStatusMessage message);
+    void update(AbstractRipper ripper, RipStatusMessage message);
 
 }


### PR DESCRIPTION
Removed public modifier for methods on interfaces because it is redundant.