### PR TITLE
Removed dead code from imgur ripper and improved getAlbumTitle

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
@@ -241,43 +241,6 @@ public class ImgurRipper extends AlbumRipper {
                             .get();
 
         // Try to use embedded JSON to retrieve images
-        Pattern p = Pattern.compile("^.*Imgur\\.Album\\.getInstance\\((.*?)\\);.*$", Pattern.DOTALL);
-        Matcher m = p.matcher(doc.body().html());
-        if (m.matches()) {
-            try {
-                JSONObject json = new JSONObject(m.group(1));
-                JSONObject jsonAlbum = json.getJSONObject("album");
-                ImgurAlbum imgurAlbum = new ImgurAlbum(url, jsonAlbum.getString("title_clean"));
-                JSONArray images = json.getJSONObject("images").getJSONArray("images");
-                int imagesLength = images.length();
-                for (int i = 0; i < imagesLength; i++) {
-                    JSONObject image = images.getJSONObject(i);
-                    String ext = image.getString("ext");
-                    if (ext.equals(".gif") && Utils.getConfigBoolean("prefer.mp4", false)) {
-                        ext = ".mp4";
-                    }
-                    URL imageURL = new URL(
-                            // CDN url is provided elsewhere in the document
-                            "http://i.imgur.com/"
-                                    + image.get("hash")
-                                    + ext);
-                    String title = null, description = null;
-                    if (image.has("title") && !image.isNull("title")) {
-                        title = image.getString("title");
-                    }
-                    if (image.has("description") && !image.isNull("description")) {
-                        description = image.getString("description");
-                    }
-                    ImgurImage imgurImage =  new ImgurImage(imageURL,
-                            title,
-                            description);
-                    imgurAlbum.addImage(imgurImage);
-                }
-                return imgurAlbum;
-            } catch (JSONException e) {
-                logger.debug("Error while parsing JSON at " + strUrl + ", continuing", e);
-            }
-        }
         p = Pattern.compile("^.*widgetFactory.mergeConfig\\('gallery', (.*?)\\);.*$", Pattern.DOTALL);
         m = p.matcher(doc.body().html());
         if (m.matches()) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
@@ -108,6 +108,13 @@ public class ImgurRipper extends AlbumRipper {
                 elems = albumDoc.select("meta[property=og:title]");
                 if (elems!=null) {
                     title = elems.attr("content");
+                    logger.debug("[*] Title is " + title);
+                }
+                // This is here encase the album is unnamed, to prevent
+                // Imgur: The most awesome images on the Internet from being added onto the album name
+                if (title.contains("Imgur: The most awesome images on the Internet")) {
+                    logger.debug("[*] Album is untitled or imgur is return no title");
+                    title = "";
                 }
 
                 String albumTitle = "imgur_";
@@ -119,7 +126,7 @@ public class ImgurRipper extends AlbumRipper {
                 */
                 albumTitle += gid;
                 if (title != null) {
-                    albumTitle += " (" + title + ")";
+                    albumTitle += "_" + title;
                 }
 
                 return albumTitle;
@@ -241,8 +248,8 @@ public class ImgurRipper extends AlbumRipper {
                             .get();
 
         // Try to use embedded JSON to retrieve images
-        p = Pattern.compile("^.*widgetFactory.mergeConfig\\('gallery', (.*?)\\);.*$", Pattern.DOTALL);
-        m = p.matcher(doc.body().html());
+        Pattern p = Pattern.compile("^.*widgetFactory.mergeConfig\\('gallery', (.*?)\\);.*$", Pattern.DOTALL);
+        Matcher m = p.matcher(doc.body().html());
         if (m.matches()) {
             try {
                 ImgurAlbum imgurAlbum = new ImgurAlbum(url);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
@@ -106,7 +106,7 @@ public class ImgurRipper extends AlbumRipper {
                 String title = null;
                 logger.info("Trying to get album title");
                 elems = albumDoc.select("meta[property=og:title]");
-                if (elems!=null) {
+                if (elems != null) {
                     title = elems.attr("content");
                     logger.debug("Title is " + title);
                 }
@@ -119,7 +119,7 @@ public class ImgurRipper extends AlbumRipper {
                     title = "";
                     logger.debug("Trying to use title tag to get title");
                     elems = albumDoc.select("title");
-                    if (elems!=null) {
+                    if (elems != null) {
                         if (elems.text().contains("Imgur: The most awesome images on the Internet")) {
                             logger.debug("Was unable to get album title or album was untitled");
                         }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
@@ -104,6 +104,7 @@ public class ImgurRipper extends AlbumRipper {
                 */
 
                 String title = null;
+                final String defaultTitle = "Imgur: The most awesome images on the Internet";
                 logger.info("Trying to get album title");
                 elems = albumDoc.select("meta[property=og:title]");
                 if (elems != null) {
@@ -112,7 +113,7 @@ public class ImgurRipper extends AlbumRipper {
                 }
                 // This is here encase the album is unnamed, to prevent
                 // Imgur: The most awesome images on the Internet from being added onto the album name
-                if (title.contains("Imgur: The most awesome images on the Internet")) {
+                if (title.contains(defaultTitle)) {
                     logger.debug("Album is untitled or imgur is returning the default title");
                     // We set the title to "" here because if it's found in the next few attempts it will be changed
                     // but if it's nto found there will be no reason to set it later
@@ -120,7 +121,7 @@ public class ImgurRipper extends AlbumRipper {
                     logger.debug("Trying to use title tag to get title");
                     elems = albumDoc.select("title");
                     if (elems != null) {
-                        if (elems.text().contains("Imgur: The most awesome images on the Internet")) {
+                        if (elems.text().contains(defaultTitle)) {
                             logger.debug("Was unable to get album title or album was untitled");
                         }
                         else {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImgurRipper.java
@@ -108,13 +108,25 @@ public class ImgurRipper extends AlbumRipper {
                 elems = albumDoc.select("meta[property=og:title]");
                 if (elems!=null) {
                     title = elems.attr("content");
-                    logger.debug("[*] Title is " + title);
+                    logger.debug("Title is " + title);
                 }
                 // This is here encase the album is unnamed, to prevent
                 // Imgur: The most awesome images on the Internet from being added onto the album name
                 if (title.contains("Imgur: The most awesome images on the Internet")) {
-                    logger.debug("[*] Album is untitled or imgur is return no title");
+                    logger.debug("Album is untitled or imgur is returning the default title");
+                    // We set the title to "" here because if it's found in the next few attempts it will be changed
+                    // but if it's nto found there will be no reason to set it later
                     title = "";
+                    logger.debug("Trying to use title tag to get title");
+                    elems = albumDoc.select("title");
+                    if (elems!=null) {
+                        if (elems.text().contains("Imgur: The most awesome images on the Internet")) {
+                            logger.debug("Was unable to get album title or album was untitled");
+                        }
+                        else {
+                            title = elems.text();
+                        }
+                    }
                 }
 
                 String albumTitle = "imgur_";


### PR DESCRIPTION
I removed a block of code that never worked and made changes to getAlbumTitle so the string "Imgur: The most awesome images on the Internet" no longer will appear in album titles on disk

I also added a fallback for title grabbing if og:title fails

Closes #509

Test link:https://imgur.com/a/9rX1v