### PR TITLE
Fixed image cropping issue

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -116,7 +116,7 @@ public class InstagramRipper extends AbstractJSONRipper {
         // Instagram returns cropped images to unauthenticated applications to maintain legacy support. 
         // To retrieve the uncropped image, remove this segment from the URL. 
         // Segment format: cX.Y.W.H
-        imageURL = imageURL.replaceAll("\/c\\d{1,4}\\.\\d{1,4}\\.\\d{1,4}\\.\\d{1,4}", "");
+        imageURL = imageURL.replaceAll("\\/c\\d{1,4}\\.\\d{1,4}\\.\\d{1,4}\\.\\d{1,4}", "");
 
         imageURL = imageURL.replaceAll("\\?ig_cache_key.+$", "");
         return imageURL;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -113,10 +113,10 @@ public class InstagramRipper extends AbstractJSONRipper {
         imageURL = imageURL.replaceAll("scontent.cdninstagram.com/hphotos-", "igcdn-photos-d-a.akamaihd.net/hphotos-ak-");
         imageURL = imageURL.replaceAll("s640x640/", "");
 
-        // it appears ig now allows higher resolution images to be uploaded but are artifically cropping the images to
-        // 1080x1080 to preserve legacy support. the cropping string below isnt present on ig website and removing it
-        // displays the uncropped image.
-        imageURL = imageURL.replaceAll("c0.114.1080.1080/", "");
+        // Instagram returns cropped images to unauthenticated applications to maintain legacy support. 
+        // To retrieve the uncropped image, remove this segment from the URL. 
+        // Segment format: cX.Y.W.H
+        imageURL = imageURL.replaceAll("\/c\\d{1,4}\\.\\d{1,4}\\.\\d{1,4}\\.\\d{1,4}", "");
 
         imageURL = imageURL.replaceAll("\\?ig_cache_key.+$", "");
         return imageURL;


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix -- which issue? #new
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Fixed an issue with cropped images being downloaded using the Instagram API


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
