### PR TITLE
Xhamster update for new URL format

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -113,10 +113,10 @@ public class InstagramRipper extends AbstractJSONRipper {
         imageURL = imageURL.replaceAll("scontent.cdninstagram.com/hphotos-", "igcdn-photos-d-a.akamaihd.net/hphotos-ak-");
         imageURL = imageURL.replaceAll("s640x640/", "");
 
-        // it appears ig now allows higher resolution images to be uploaded but are artifically cropping the images to
-        // 1080x1080 to preserve legacy support. the cropping string below isnt present on ig website and removing it
-        // displays the uncropped image.
-        imageURL = imageURL.replaceAll("c0.114.1080.1080/", "");
+        // Instagram returns cropped images to unauthenticated applications to maintain legacy support. 
+        // To retrieve the uncropped image, remove this segment from the URL. 
+        // Segment format: cX.Y.W.H - eg: c0.134.1080.1080
+        imageURL = imageURL.replaceAll("\\/c\\d{1,4}\\.\\d{1,4}\\.\\d{1,4}\\.\\d{1,4}", "");
 
         imageURL = imageURL.replaceAll("\\?ig_cache_key.+$", "");
         return imageURL;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -23,7 +23,7 @@ public class XhamsterRipper extends AlbumRipper {
 
     @Override
     public boolean canRip(URL url) {
-        Pattern p = Pattern.compile("^https?://[wmde.]*xhamster\\.com/photos/gallery/[0-9]+.*$");
+        Pattern p = Pattern.compile("^https?://[wmde.]*xhamster\\.com/photos/gallery/.*[0-9]+$");
         Matcher m = p.matcher(url.toExternalForm());
         return m.matches();
     }
@@ -87,14 +87,14 @@ public class XhamsterRipper extends AlbumRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("^https?://([a-z0-9.]*?)xhamster\\.com/photos/gallery/([0-9]{1,})/.*\\.html");
+        Pattern p = Pattern.compile("^https?://[wmde.]*xhamster\\.com/photos/gallery/.*?(\\d{1,})$");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
-            return m.group(2);
+            return m.group(1);
         }
         throw new MalformedURLException(
                 "Expected xhamster.com gallery formats: "
-                        + "xhamster.com/photos/gallery/#####/xxxxx..html"
+                        + "xhamster.com/photos/gallery/xxxxx-#####"
                         + " Got: " + url);
     }
 

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BasicRippersTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BasicRippersTest.java
@@ -276,7 +276,7 @@ public class BasicRippersTest extends RippersTest {
     }
 
     public void testXhamsterAlbums() throws IOException {
-        XhamsterRipper ripper = new XhamsterRipper(new URL("http://xhamster.com/photos/gallery/1462237/alyssa_gadson.html"));
+        XhamsterRipper ripper = new XhamsterRipper(new URL("https://xhamster.com/photos/gallery/volleyball-sluts-8305007"));
         testRipper(ripper);
     }
 }


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix -- which issue? #575 
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Updated the xhamster ripper to support the new URl format

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
