### PR TITLE
Instagram: [standard_resolution] is not a JSONObject.

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -125,9 +125,15 @@ public class InstagramRipper extends AbstractJSONRipper {
     private String getMedia(JSONObject data) {
         String imageURL = "";
         if (data.has("videos")) {
-            imageURL = data.getJSONObject("videos").getJSONObject("standard_resolution").getString("url");
+        	JSONObject videosObject = data.getJSONObject("videos");
+			if (!videosObject.isNull("standard_resolution")) {
+        		imageURL = videosObject.getJSONObject("standard_resolution").getString("url");
+        	}
         } else if (data.has("images")) {
-           imageURL = data.getJSONObject("images").getJSONObject("standard_resolution").getString("url");
+        	JSONObject imagesObject = data.getJSONObject("images");
+			if (!imagesObject.isNull("standard_resolution")) {
+        		imageURL = imagesObject.getJSONObject("standard_resolution").getString("url");
+        	}
         }
         return imageURL;
     }
@@ -145,14 +151,14 @@ public class InstagramRipper extends AbstractJSONRipper {
                 for (int carouselIndex = 0; carouselIndex < carouselMedias.length(); carouselIndex++) {
                     JSONObject carouselMedia = (JSONObject) carouselMedias.get(carouselIndex);
                     String imageURL = getMedia(carouselMedia);
-                    if (!imageURL.equals("")) {
+                    if (!"".equals(imageURL)) {
                         imageURL = getOriginalUrl(imageURL);
                         imageURLs.add(imageURL);
                     }
                 }
             } else {
                 String imageURL = getMedia(data);
-                if (!imageURL.equals("")) {
+                if (!"".equals(imageURL)) {
                     imageURL = getOriginalUrl(imageURL);
                     imageURLs.add(imageURL);
                 }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -124,13 +124,14 @@ public class InstagramRipper extends AbstractJSONRipper {
 
     private String getMedia(JSONObject data) {
         String imageURL = "";
+		JSONObject mediaObject;
         if (data.has("videos")) {
-        	JSONObject videosObject = data.getJSONObject("videos");
+        	mediaObject = data.getJSONObject("videos");
 			if (!videosObject.isNull("standard_resolution")) {
         		imageURL = videosObject.getJSONObject("standard_resolution").getString("url");
         	}
         } else if (data.has("images")) {
-        	JSONObject imagesObject = data.getJSONObject("images");
+        	mediaObject = data.getJSONObject("images");
 			if (!imagesObject.isNull("standard_resolution")) {
         		imageURL = imagesObject.getJSONObject("standard_resolution").getString("url");
         	}


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix -- which issue? Fix #600 
* [ ] a new Ripper
* [x] a refactoring
* [ ] a style change/fix


# Description

Please add details about your change here.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
