### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "java10"
+run = "mvn test"

--- a/README.md
+++ b/README.md
@@ -82,3 +82,4 @@ mvn test
 * commons-cli-1.2
 * commons-io-1.3.2
 * httpcomponents-4.3.3
+[![Run on Repl.it](https://repl.it/badge/github/4pr0n/ripme)](https://repl.it/github/4pr0n/ripme)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).

<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# We've moved to [ripmeapp/ripme](https://github.com/RipMeApp/ripme)!

Please consider opening your Pull Request there!

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix -- which issue? #...
* [x] a new Ripper
* [x] a refactoring
* [x] a style change/fix


# Description

Please add details about your change here.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
